### PR TITLE
docs(contributing): update code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@
 
 All members of the project community must abide by the [SAP Open Source Code of Conduct](https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md).
 Only by respecting each other we can develop a productive, collaborative community.
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [a project maintainer](.reuse/dep5).
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [ospo@sap.com](mailto:ospo@sap.com) (SAP Open Source Program Office). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Engaging in Our Project
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the controller-utils library which provides utility fun
 ## Requirements and Setup
 
 ```bash
-$ go get  github.com/openmcp-project/controller-utils@latest
+$ go get github.com/openmcp-project/controller-utils@latest
 ```
 
 
@@ -21,7 +21,7 @@ The `pkg/clientconfig` package provides helper functions for creating Kubernetes
 
 #### Noteworthy Functions
 
-- `GetRESTConfig` generates a `*rest.Config` for interacting with the Kubernetes API. It supports using a kubeconfig string, a kubeconfig file path, a secret reference that contains a kubeconfig file or a Service Account. 
+- `GetRESTConfig` generates a `*rest.Config` for interacting with the Kubernetes API. It supports using a kubeconfig string, a kubeconfig file path, a secret reference that contains a kubeconfig file or a Service Account.
 - `GetClient` creates a client.Client for managing Kubernetes resources.
 
 ### Webhooks

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you find any bug that may be a security problem, please follow our instructio
 
 ## Code of Conduct
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md) at all times.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/openmcp-project/.github/blob/main/CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
 


### PR DESCRIPTION
This PR fixes the code of conduct in the CONTRIBUTING.md like already done in [openmcp-project/project-workspace-operator@`e8f5daa` (#5)](https://github.com/openmcp-project/project-workspace-operator/pull/5/commits/e8f5daa34d30d15af73c5847889191f9e9d22443). Additionally, this PR fixes a typo in the README.
