### PR TITLE
feat: delete and get options

### DIFF
--- a/pkg/resources/mutator.go
+++ b/pkg/resources/mutator.go
@@ -15,9 +15,9 @@ type Mutator[K client.Object] interface {
 	MetadataMutator() MetadataMutator
 }
 
-func GetResource[K client.Object](ctx context.Context, clt client.Client, m Mutator[K]) (K, error) {
+func GetResource[K client.Object](ctx context.Context, clt client.Client, m Mutator[K], opts ...client.GetOption) (K, error) {
 	res := m.Empty()
-	if err := clt.Get(ctx, client.ObjectKeyFromObject(res), res); err != nil {
+	if err := clt.Get(ctx, client.ObjectKeyFromObject(res), res, opts...); err != nil {
 		return res, fmt.Errorf("failed to get %s: %w", m.String(), err)
 	}
 	return res, nil
@@ -34,9 +34,9 @@ func CreateOrUpdateResource[K client.Object](ctx context.Context, clt client.Cli
 	return nil
 }
 
-func DeleteResource[K client.Object](ctx context.Context, clt client.Client, m Mutator[K]) error {
+func DeleteResource[K client.Object](ctx context.Context, clt client.Client, m Mutator[K], opts ...client.DeleteOption) error {
 	res := m.Empty()
-	if err := clt.Delete(ctx, res); client.IgnoreNotFound(err) != nil {
+	if err := clt.Delete(ctx, res, opts...); client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("failed to delete %s: %w", m.String(), err)
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

With this change, `client.DeleteOptions` and `client.GetOptions` are supported in the `DeleteResource` and `GetResource` methods of the resources package.

Possible use case: the options can be used to specify a PropagationPolicy for a delete operation, so that for example the deletion of a Job leads to the deletion of its Pods.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- Support for client.DeleteOptions and client.GetOptions.
```
