### PR TITLE
extend testing library

### DIFF
--- a/pkg/testing/complex_environment.go
+++ b/pkg/testing/complex_environment.go
@@ -35,6 +35,8 @@ func DefaultScheme() *runtime.Scheme {
 	return sc
 }
 
+var noMatcher types.GomegaMatcher = nil
+
 ///////////////////////////
 /// COMPLEX ENVIRONMENT ///
 ///////////////////////////
@@ -86,7 +88,7 @@ func (e *ComplexEnvironment) shouldEventuallyReconcile(reconciler string, req re
 
 // ShouldNotReconcile calls the given reconciler with the given request and expects an error.
 func (e *ComplexEnvironment) ShouldNotReconcile(reconciler string, req reconcile.Request, optionalDescription ...interface{}) reconcile.Result {
-	return e.shouldNotReconcile(reconciler, req, nil, optionalDescription...)
+	return e.shouldNotReconcile(reconciler, req, noMatcher, optionalDescription...)
 }
 
 // ShouldNotReconcileWithError calls the given reconciler with the given request and expects an error that matches the given matcher.
@@ -102,7 +104,7 @@ func (e *ComplexEnvironment) shouldNotReconcile(reconciler string, req reconcile
 
 // ShouldEventuallyNotReconcile calls the given reconciler with the given request and retries until an error occurred or the timeout is reached.
 func (e *ComplexEnvironment) ShouldEventuallyNotReconcile(reconciler string, req reconcile.Request, timeout, poll time.Duration, optionalDescription ...interface{}) reconcile.Result {
-	return e.shouldEventuallyNotReconcile(reconciler, req, nil, timeout, poll, optionalDescription...)
+	return e.shouldEventuallyNotReconcile(reconciler, req, noMatcher, timeout, poll, optionalDescription...)
 }
 
 // ShouldEventuallyNotReconcileWithError calls the given reconciler with the given request and retries until an error that matches the given matcher occurred or the timeout is reached.

--- a/pkg/testing/complex_environment.go
+++ b/pkg/testing/complex_environment.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/openmcp-project/controller-utils/pkg/logging"
@@ -121,6 +123,7 @@ type ComplexEnvironmentBuilder struct {
 	ClusterInitObjectPaths  map[string][]string
 	ClientCreationCallbacks map[string][]func(client.Client)
 	loggerIsSet             bool
+	InjectUIDs              map[string]bool
 }
 
 type ClusterEnvironment struct {
@@ -163,6 +166,7 @@ func NewComplexEnvironmentBuilder() *ComplexEnvironmentBuilder {
 		ClusterStatusObjects:    map[string][]client.Object{},
 		ClusterInitObjectPaths:  map[string][]string{},
 		ClientCreationCallbacks: map[string][]func(client.Client){},
+		InjectUIDs:              map[string]bool{},
 	}
 }
 
@@ -264,6 +268,16 @@ func (eb *ComplexEnvironmentBuilder) WithAfterClientCreationCallback(name string
 	return eb
 }
 
+// WithUIDs enables UID injection for the specified cluster.
+// All objects that are initially loaded or afterwards created via the client's 'Create' method will have a random UID injected, if they do not already have one.
+// Note that this function registers an interceptor function, which will be overwritten if 'WithFakeClientBuilderCall(..., "WithInterceptorFuncs", ...)' is also called.
+// This would lead to newly created objects not having a UID injected.
+// To avoid this, pass 'InjectUIDOnObjectCreation(...)' into the interceptor.Funcs' Create field. The argument allows to inject your own additional Create logic, if desired.
+func (eb *ComplexEnvironmentBuilder) WithUIDs(name string) *ComplexEnvironmentBuilder {
+	eb.InjectUIDs[name] = true
+	return eb
+}
+
 // WithFakeClientBuilderCall allows to inject method calls to fake.ClientBuilder when the fake clients are created during Build().
 // The fake clients are usually created using WithScheme(...).WithObjects(...).WithStatusSubresource(...).Build().
 // This function allows to inject additional method calls. It is only required for advanced use-cases.
@@ -284,6 +298,8 @@ func (eb *ComplexEnvironmentBuilder) WithFakeClientBuilderCall(name string, meth
 // Build constructs the environment from the builder.
 // Note that this function panics instead of throwing an error,
 // as it is intended to be used in tests, where all information is static anyway.
+//
+//nolint:gocyclo
 func (eb *ComplexEnvironmentBuilder) Build() *ComplexEnvironment {
 	res := eb.internal
 
@@ -334,6 +350,18 @@ func (eb *ComplexEnvironmentBuilder) Build() *ComplexEnvironment {
 			}
 			if len(eb.ClusterInitObjects) > 0 {
 				objs = append(objs, eb.ClusterInitObjects[name]...)
+			}
+			if eb.InjectUIDs[name] {
+				// ensure that objects have a uid
+				for _, obj := range objs {
+					if obj.GetUID() == "" {
+						// set a random UID if not already set
+						obj.SetUID(uuid.NewUUID())
+					}
+				}
+				fcb.WithInterceptorFuncs(interceptor.Funcs{
+					Create: InjectUIDOnObjectCreation(nil),
+				})
 			}
 			statusObjs := []client.Object{}
 			statusObjs = append(statusObjs, objs...)
@@ -395,4 +423,20 @@ func (eb *ComplexEnvironmentBuilder) Build() *ComplexEnvironment {
 	}
 
 	return res
+}
+
+// InjectUIDOnObjectCreation returns an interceptor function for Create which injects a random UID into the object, if it does not already have one.
+// If additionalLogic is nil, the object is created regularly afterwards.
+// Otherwise, additionalLogic is called.
+// If you called 'WithUIDs(...)' on the ComplexEnvironmentBuilder AND 'WithFakeClientBuilderCall(..., "WithInterceptorFuncs", ...)', then you need to pass this function into the interceptor.Funcs' Create field, optionally adding your own creation logic via additionalLogic.
+func InjectUIDOnObjectCreation(additionalLogic func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error) func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+	return func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+		if obj.GetUID() == "" {
+			obj.SetUID(uuid.NewUUID())
+		}
+		if additionalLogic != nil {
+			return additionalLogic(ctx, client, obj, opts...)
+		}
+		return client.Create(ctx, obj, opts...)
+	}
 }

--- a/pkg/testing/environment.go
+++ b/pkg/testing/environment.go
@@ -153,6 +153,16 @@ func (eb *EnvironmentBuilder) WithAfterClientCreationCallback(callback func(clie
 	return eb
 }
 
+// WithUIDs enables UID injection.
+// All objects that are initially loaded or afterwards created via the client's 'Create' method will have a random UID injected, if they do not already have one.
+// Note that this function registers an interceptor function, which will be overwritten if 'WithFakeClientBuilderCall("WithInterceptorFuncs", ...)' is also called.
+// This would lead to newly created objects not having a UID injected.
+// To avoid this, pass 'InjectUIDOnObjectCreation(...)' into the interceptor.Funcs' Create field. The argument allows to inject your own additional Create logic, if desired.
+func (eb *EnvironmentBuilder) WithUIDs() *EnvironmentBuilder {
+	eb.ComplexEnvironmentBuilder.WithUIDs(SimpleEnvironmentDefaultKey)
+	return eb
+}
+
 // WithFakeClientBuilderCall allows to inject method calls to fake.ClientBuilder when the fake client is created during Build().
 // The fake client is usually created using WithScheme(...).WithObjects(...).WithStatusSubresource(...).Build().
 // This function allows to inject additional method calls. It is only required for advanced use-cases.

--- a/pkg/testing/environment.go
+++ b/pkg/testing/environment.go
@@ -8,6 +8,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/onsi/gomega/types"
+
 	"github.com/openmcp-project/controller-utils/pkg/logging"
 )
 
@@ -48,12 +50,22 @@ func (e *Environment) ShouldEventuallyReconcile(req reconcile.Request, timeout, 
 
 // ShouldNotReconcile calls the given reconciler with the given request and expects an error.
 func (e *Environment) ShouldNotReconcile(req reconcile.Request, optionalDescription ...interface{}) reconcile.Result {
-	return e.shouldNotReconcile(SimpleEnvironmentDefaultKey, req, optionalDescription...)
+	return e.shouldNotReconcile(SimpleEnvironmentDefaultKey, req, nil, optionalDescription...)
 }
 
 // ShouldEventuallyNotReconcile calls the given reconciler with the given request and retries until an error occurred or the timeout is reached.
 func (e *Environment) ShouldEventuallyNotReconcile(req reconcile.Request, timeout, poll time.Duration, optionalDescription ...interface{}) reconcile.Result {
-	return e.shouldEventuallyNotReconcile(SimpleEnvironmentDefaultKey, req, timeout, poll, optionalDescription...)
+	return e.shouldEventuallyNotReconcile(SimpleEnvironmentDefaultKey, req, nil, timeout, poll, optionalDescription...)
+}
+
+// ShouldNotReconcileWithError calls the given reconciler with the given request and expects an error that matches the given matcher.
+func (e *Environment) ShouldNotReconcileWithError(req reconcile.Request, matcher types.GomegaMatcher, optionalDescription ...interface{}) reconcile.Result {
+	return e.shouldNotReconcile(SimpleEnvironmentDefaultKey, req, matcher, optionalDescription...)
+}
+
+// ShouldEventuallyNotReconcileWithError calls the given reconciler with the given request and retries until an error that matches the given matcher occurred or the timeout is reached.
+func (e *Environment) ShouldEventuallyNotReconcileWithError(req reconcile.Request, matcher types.GomegaMatcher, timeout, poll time.Duration, optionalDescription ...interface{}) reconcile.Result {
+	return e.shouldEventuallyNotReconcile(SimpleEnvironmentDefaultKey, req, matcher, timeout, poll, optionalDescription...)
 }
 
 //////////////////////////////////

--- a/pkg/testing/matchers/maybematch.go
+++ b/pkg/testing/matchers/maybematch.go
@@ -1,0 +1,44 @@
+package matchers
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/types"
+)
+
+// MaybeMatch returns a Gomega matcher that passes the matching logic to the provided matcher,
+// but always succeeds if the passed in matcher is nil.
+func MaybeMatch(matcher types.GomegaMatcher) types.GomegaMatcher {
+	return &maybeMatcher{matcher: matcher}
+}
+
+type maybeMatcher struct {
+	matcher types.GomegaMatcher
+}
+
+func (m *maybeMatcher) GomegaString() string {
+	if m == nil || m.matcher == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("MaybeMatch(%v)", m.matcher)
+}
+
+var _ types.GomegaMatcher = &maybeMatcher{}
+
+// Match implements types.GomegaMatcher.
+func (m *maybeMatcher) Match(actualRaw any) (success bool, err error) {
+	if m.matcher == nil {
+		return true, nil
+	}
+	return m.matcher.Match(actualRaw)
+}
+
+// FailureMessage implements types.GomegaMatcher.
+func (m *maybeMatcher) FailureMessage(actual any) (message string) {
+	return m.matcher.FailureMessage(actual)
+}
+
+// NegatedFailureMessage implements types.GomegaMatcher.
+func (m *maybeMatcher) NegatedFailureMessage(actual any) (message string) {
+	return m.matcher.NegatedFailureMessage(actual)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds two functionalities to the testing library:
- The (Complex)Environment can now be instructed to inject UIDs into k8s objects, which the fake client doesn't do by default.
- Further methods have been added to match the error returned by a failed reconciliation, which was not possible with the `ShouldNotReconcile` function (and its relatives) before.

**Which issue(s) this PR fixes**:
Required for https://github.com/openmcp-project/openmcp-operator/pull/67
Required for https://github.com/openmcp-project/mcp-operator/pull/103

**Special notes for your reviewer**:
Refactored out of #66 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The testing library's `ComplexEnvironment` and `Environment` types can now be configured to add UIDs to created resources (the fake client doesn't do this). Use the `WithUIDs` method in the builder and additionally use `InjectUIDOnObjectCreation` if you overwrite the fake client's interceptor funcs to enable this functionality.
```
```feature developer
Next to the `ShouldNotReconcile`/`ShouldEventuallyNotReconcile` methods from the testing library's `Environment`/`ComplexEnvironment` types, there are now `ShouldNotReconcileWithError` and `ShouldEventuallyNotReconcileWithError` which allow to verify properties of the error returned by the reconciliation in addition to ensuring that one occurred.
```
