### PR TITLE
Adapt condition updater to use metav1.Condition

### DIFF
--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -1,50 +1,59 @@
 package conditions
 
-import "time"
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
-// Condition represents a condition consisting of type, status, reason, message and a last transition timestamp.
-type Condition[T comparable] interface {
-	// SetStatus sets the status of the condition.
-	SetStatus(status T)
-	// GetStatus returns the status of the condition.
-	GetStatus() T
-
-	// SetType sets the type of the condition.
-	SetType(conType string)
-	// GetType returns the type of the condition.
-	GetType() string
-
-	// SetLastTransitionTime sets the timestamp of the condition.
-	SetLastTransitionTime(timestamp time.Time)
-	// GetLastTransitionTime returns the timestamp of the condition.
-	GetLastTransitionTime() time.Time
-
-	// SetReason sets the reason of the condition.
-	SetReason(reason string)
-	// GetReason returns the reason of the condition.
-	GetReason() string
-
-	// SetMessage sets the message of the condition.
-	SetMessage(message string)
-	// GetMessage returns the message of the condition.
-	GetMessage() string
+// GetCondition is an alias for apimeta.FindStatusCondition.
+// It returns a pointer to the condition of the specified type from the given conditions slice, or nil if not found.
+func GetCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	return apimeta.FindStatusCondition(conditions, conditionType)
 }
 
-// GetCondition returns a pointer to the condition for the given type, if it exists.
-// Otherwise, nil is returned.
-func GetCondition[T comparable](ccl []Condition[T], t string) Condition[T] {
-	for i := range ccl {
-		if ccl[i].GetType() == t {
-			return ccl[i]
-		}
+// FromBoolPointer returns the metav1.ConditionStatus that matches the given bool pointer.
+// nil = ConditionUnknown
+// true = ConditionTrue
+// false = ConditionFalse
+func FromBoolPointer(status *bool) metav1.ConditionStatus {
+	if status == nil {
+		return metav1.ConditionUnknown
 	}
-	return nil
+	if *status {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
+}
+
+// FromBool returns the metav1.ConditionStatus that matches the given bool value.
+// true = ConditionTrue
+// false = ConditionFalse
+func FromBool(status bool) metav1.ConditionStatus {
+	return FromBoolPointer(&status)
+}
+
+// ToBoolPointer is the inverse of FromBoolPointer.
+// It returns a pointer to a bool that matches the given ConditionStatus.
+// If the status is ConditionTrue, it returns a pointer to true.
+// If the status is ConditionFalse, it returns a pointer to false.
+// If the status is ConditionUnknown or any unknown value, it returns nil.
+func ToBoolPointer(status metav1.ConditionStatus) *bool {
+	var res *bool
+	switch status {
+	case metav1.ConditionTrue:
+		tmp := true
+		res = &tmp
+	case metav1.ConditionFalse:
+		tmp := false
+		res = &tmp
+	}
+	return res
 }
 
 // AllConditionsHaveStatus returns true if all conditions have the specified status.
-func AllConditionsHaveStatus[T comparable](status T, conditions ...Condition[T]) bool {
+func AllConditionsHaveStatus(status metav1.ConditionStatus, conditions ...metav1.Condition) bool {
 	for _, con := range conditions {
-		if con.GetStatus() != status {
+		if con.Status != status {
 			return false
 		}
 	}

--- a/pkg/conditions/updater.go
+++ b/pkg/conditions/updater.go
@@ -3,18 +3,17 @@ package conditions
 import (
 	"slices"
 	"strings"
-	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // conditionUpdater is a helper struct for updating a list of Conditions.
 // Use the ConditionUpdater constructor for initializing.
-type conditionUpdater[T comparable] struct {
-	Now        time.Time
-	conditions map[string]Condition[T]
+type conditionUpdater struct {
+	Now        metav1.Time
+	conditions map[string]metav1.Condition
 	updated    sets.Set[string]
-	construct  func() Condition[T]
 	changed    bool
 }
 
@@ -30,15 +29,14 @@ type conditionUpdater[T comparable] struct {
 //
 // Usage example:
 // status.conditions = ConditionUpdater(status.conditions, true).UpdateCondition(...).UpdateCondition(...).Conditions()
-func ConditionUpdater[T comparable](construct func() Condition[T], conditions []Condition[T], removeUntouched bool) *conditionUpdater[T] {
-	res := &conditionUpdater[T]{
-		Now:        time.Now(),
-		conditions: make(map[string]Condition[T], len(conditions)),
-		construct:  construct,
+func ConditionUpdater(conditions []metav1.Condition, removeUntouched bool) *conditionUpdater {
+	res := &conditionUpdater{
+		Now:        metav1.Now(),
+		conditions: make(map[string]metav1.Condition, len(conditions)),
 		changed:    false,
 	}
 	for _, con := range conditions {
-		res.conditions[con.GetType()] = con
+		res.conditions[con.Type] = con
 	}
 	if removeUntouched {
 		res.updated = sets.New[string]()
@@ -49,21 +47,23 @@ func ConditionUpdater[T comparable](construct func() Condition[T], conditions []
 // UpdateCondition updates or creates the condition with the specified type.
 // All fields of the condition are updated with the values given in the arguments, but the condition's LastTransitionTime is only updated (with the timestamp contained in the receiver struct) if the status changed.
 // Returns the receiver for easy chaining.
-func (c *conditionUpdater[T]) UpdateCondition(conType string, status T, reason, message string) *conditionUpdater[T] {
-	con := c.construct()
-	con.SetType(conType)
-	con.SetStatus(status)
-	con.SetReason(reason)
-	con.SetMessage(message)
-	con.SetLastTransitionTime(c.Now)
+func (c *conditionUpdater) UpdateCondition(conType string, status metav1.ConditionStatus, observedGeneration int64, reason, message string) *conditionUpdater {
+	con := metav1.Condition{
+		Type:               conType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: observedGeneration,
+		LastTransitionTime: c.Now,
+	}
 	old, ok := c.conditions[conType]
-	if ok && old.GetStatus() == con.GetStatus() {
+	if ok && old.Status == con.Status {
 		// update LastTransitionTime only if status changed
-		con.SetLastTransitionTime(old.GetLastTransitionTime())
+		con.LastTransitionTime = old.LastTransitionTime
 	}
 	if !c.changed {
 		if ok {
-			c.changed = old.GetStatus() != con.GetStatus() || old.GetReason() != con.GetReason() || old.GetMessage() != con.GetMessage()
+			c.changed = old.Status != con.Status || old.Reason != con.Reason || old.Message != con.Message
 		} else {
 			c.changed = true
 		}
@@ -76,18 +76,18 @@ func (c *conditionUpdater[T]) UpdateCondition(conType string, status T, reason, 
 }
 
 // UpdateConditionFromTemplate is a convenience wrapper around UpdateCondition which allows it to be called with a preconstructed ComponentCondition.
-func (c *conditionUpdater[T]) UpdateConditionFromTemplate(con Condition[T]) *conditionUpdater[T] {
-	return c.UpdateCondition(con.GetType(), con.GetStatus(), con.GetReason(), con.GetMessage())
+func (c *conditionUpdater) UpdateConditionFromTemplate(con metav1.Condition) *conditionUpdater {
+	return c.UpdateCondition(con.Type, con.Status, con.ObservedGeneration, con.Reason, con.Message)
 }
 
 // HasCondition returns true if a condition with the given type exists in the updated condition list.
-func (c *conditionUpdater[T]) HasCondition(conType string) bool {
+func (c *conditionUpdater) HasCondition(conType string) bool {
 	_, ok := c.conditions[conType]
 	return ok && (c.updated == nil || c.updated.Has(conType))
 }
 
 // RemoveCondition removes the condition with the given type from the updated condition list.
-func (c *conditionUpdater[T]) RemoveCondition(conType string) *conditionUpdater[T] {
+func (c *conditionUpdater) RemoveCondition(conType string) *conditionUpdater {
 	if !c.HasCondition(conType) {
 		return c
 	}
@@ -104,21 +104,21 @@ func (c *conditionUpdater[T]) RemoveCondition(conType string) *conditionUpdater[
 // in between the condition updater creation and this method call. Otherwise, it will potentially also contain old conditions.
 // The conditions are returned sorted by their type.
 // The second return value indicates whether the condition list has actually changed.
-func (c *conditionUpdater[T]) Conditions() ([]Condition[T], bool) {
-	res := make([]Condition[T], 0, len(c.conditions))
+func (c *conditionUpdater) Conditions() ([]metav1.Condition, bool) {
+	res := make([]metav1.Condition, 0, len(c.conditions))
 	for _, con := range c.conditions {
 		if c.updated == nil {
 			res = append(res, con)
 			continue
 		}
-		if c.updated.Has(con.GetType()) {
+		if c.updated.Has(con.Type) {
 			res = append(res, con)
 		} else {
 			c.changed = true
 		}
 	}
-	slices.SortStableFunc(res, func(a, b Condition[T]) int {
-		return strings.Compare(a.GetType(), b.GetType())
+	slices.SortStableFunc(res, func(a, b metav1.Condition) int {
+		return strings.Compare(a.Type, b.Type)
 	})
 	return res, c.changed
 }

--- a/pkg/controller/openmcp.go
+++ b/pkg/controller/openmcp.go
@@ -1,0 +1,17 @@
+package controller
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+////////////////////
+// STATUS UPDATER //
+////////////////////
+
+// NewOpenMCPStatusUpdaterBuilder returns a StatusUpdaterBuilder that expects only ObservedGeneration, Conditions, and Phase as status fields.
+// It does not include LastReconcileTime, Reason, or Message.
+func NewOpenMCPStatusUpdaterBuilder[Obj client.Object]() *StatusUpdaterBuilder[Obj] {
+	return NewStatusUpdaterBuilder[Obj]().WithoutFields(
+		STATUS_FIELD_LAST_RECONCILE_TIME,
+		STATUS_FIELD_REASON,
+		STATUS_FIELD_MESSAGE,
+	)
+}

--- a/pkg/controller/testdata/test-02/co_status.yaml
+++ b/pkg/controller/testdata/test-02/co_status.yaml
@@ -8,12 +8,15 @@ status:
   conditions:
   - type: "TestConditionTrue"
     status: "True"
+    observedGeneration: 0
     lastTransitionTime: "2023-10-01T00:00:00Z"
   - type: "TestConditionFalse"
     status: "Unknown"
+    observedGeneration: 0
     lastTransitionTime: "2023-10-01T00:00:00Z"
   - type: "AdditionalCondition"
     status: "True"
+    observedGeneration: 0
     lastTransitionTime: "2023-10-01T00:00:00Z"
   observedGeneration: 0
   phase: "Failed"

--- a/pkg/testing/matchers/conditions.go
+++ b/pkg/testing/matchers/conditions.go
@@ -2,125 +2,93 @@ package matchers
 
 import (
 	"fmt"
-	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/onsi/gomega/types"
 
-	"github.com/openmcp-project/controller-utils/pkg/conditions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MatchCondition returns a Gomega matcher that checks if a Condition is equal to the expected one.
 // If the passed in 'actual' is not a Condition, the matcher will fail.
 // All fields which are set to their zero value in the expected condition will be ignored.
-func MatchCondition[T comparable](con *ConditionImpl[T]) types.GomegaMatcher {
-	return &conditionMatcher[T]{expected: con}
+// Use one of the TestCondition... constructors to create a Condition that can be used with this matcher.
+func MatchCondition(con *Condition) types.GomegaMatcher {
+	return &conditionMatcher{expected: con}
 }
 
-type conditionMatcher[T comparable] struct {
-	expected *ConditionImpl[T]
+type conditionMatcher struct {
+	expected *Condition
 }
 
-func (c *conditionMatcher[T]) GomegaString() string {
+func (c *conditionMatcher) GomegaString() string {
 	if c == nil || c.expected == nil {
 		return "<nil>"
 	}
 	return c.expected.String()
 }
 
-var _ types.GomegaMatcher = &conditionMatcher[bool]{}
+var _ types.GomegaMatcher = &conditionMatcher{}
 
 // Match implements types.GomegaMatcher.
-func (c *conditionMatcher[T]) Match(actualRaw any) (success bool, err error) {
-	actual, converted := actualRaw.(conditions.Condition[T])
-	if !converted {
-		// actualRaw doesn't implement conditions.Condition[T], check if a pointer to it does
-		ptrValue := reflect.New(reflect.TypeOf(actualRaw))
-		reflect.Indirect(ptrValue).Set(reflect.ValueOf(actualRaw))
-		actual, converted = ptrValue.Interface().(conditions.Condition[T])
+func (c *conditionMatcher) Match(actualRaw any) (success bool, err error) {
+	if actualRaw == nil {
+		return c.expected.Matches(nil), nil
 	}
-	if !converted {
-		return false, fmt.Errorf("expected actual (or &actual) to be of type Condition[%s], got %T", reflect.TypeFor[T]().Name(), actualRaw)
+	switch actual := actualRaw.(type) {
+	case *Condition:
+		return c.expected.Matches(actual), nil
+	case Condition:
+		return c.expected.Matches(&actual), nil
+	case *metav1.Condition:
+		return c.expected.Matches(TestConditionFromCondition(*actual)), nil
+	case metav1.Condition:
+		return c.expected.Matches(TestConditionFromCondition(actual)), nil
+	default:
+		return false, fmt.Errorf("expected actual (or &actual) to be of type Condition or metav1.Condition, got %T", actualRaw)
 	}
-	if actual == nil && c.expected == nil {
-		return true, nil
-	}
-	if actual == nil || c.expected == nil {
-		return false, nil
-	}
-	if c.expected.HasType() && c.expected.GetType() != actual.GetType() {
-		return false, nil
-	}
-	if c.expected.HasStatus() && c.expected.GetStatus() != actual.GetStatus() {
-		return false, nil
-	}
-	if c.expected.HasReason() && c.expected.GetReason() != actual.GetReason() {
-		return false, nil
-	}
-	if c.expected.HasMessage() && c.expected.GetMessage() != actual.GetMessage() {
-		return false, nil
-	}
-	if c.expected.HasLastTransitionTime() && c.expected.GetLastTransitionTime().Sub(actual.GetLastTransitionTime()) > c.expected.timestampTolerance {
-		return false, nil
-	}
-	return true, nil
 }
 
 // FailureMessage implements types.GomegaMatcher.
-func (c *conditionMatcher[T]) FailureMessage(actual interface{}) (message string) {
+func (c *conditionMatcher) FailureMessage(actual any) (message string) {
 	return fmt.Sprintf("Expected\n\t%#v\nto equal \n\t%#v", actual, c.expected)
 }
 
 // NegatedFailureMessage implements types.GomegaMatcher.
-func (c *conditionMatcher[T]) NegatedFailureMessage(actual interface{}) (message string) {
+func (c *conditionMatcher) NegatedFailureMessage(actual any) (message string) {
 	return fmt.Sprintf("Expected\n\t%#v\nto not equal \n\t%#v", actual, c.expected)
 }
 
-func NewCondition[T comparable]() conditions.Condition[T] {
-	return NewConditionImpl[T]()
-}
-
-func NewConditionImpl[T comparable]() *ConditionImpl[T] {
-	return &ConditionImpl[T]{}
-}
-
-func NewConditionImplFromValues[T comparable](conType string, status T, reason, message string, now time.Time) *ConditionImpl[T] {
-	return &ConditionImpl[T]{
-		status:             &status,
-		conType:            &conType,
-		reason:             &reason,
-		message:            &message,
-		lastTransitionTime: &now,
-	}
-}
-
-func NewConditionImplFromCondition[T comparable](con conditions.Condition[T]) *ConditionImpl[T] {
-	return NewConditionImplFromValues(con.GetType(), con.GetStatus(), con.GetReason(), con.GetMessage(), con.GetLastTransitionTime())
-}
-
-type ConditionImpl[T comparable] struct {
-	status             *T
+type Condition struct {
+	status             *metav1.ConditionStatus
 	conType            *string
+	observedGeneration *int64
 	reason             *string
 	message            *string
-	lastTransitionTime *time.Time
+	lastTransitionTime *metav1.Time
 	timestampTolerance time.Duration
 }
 
-func (c *ConditionImpl[T]) String() string {
+func (c *Condition) String() string {
 	if c == nil {
 		return "<nil>"
 	}
-	var status, conType, reason, message, lastTransitionTime string
+	var status, conType, observedGeneration, reason, message, lastTransitionTime string
 	if c.status == nil {
 		status = "<arbitrary>"
 	} else {
-		status = fmt.Sprintf("%v", *c.status)
+		status = string(*c.status)
 	}
 	if c.conType == nil {
 		conType = "<arbitrary>"
 	} else {
 		conType = *c.conType
+	}
+	if c.observedGeneration == nil {
+		observedGeneration = "<arbitrary>"
+	} else {
+		observedGeneration = strconv.FormatInt(*c.observedGeneration, 10)
 	}
 	if c.reason == nil {
 		reason = "<arbitrary>"
@@ -137,101 +105,126 @@ func (c *ConditionImpl[T]) String() string {
 	} else {
 		lastTransitionTime = c.lastTransitionTime.Format(time.RFC3339)
 	}
-	return fmt.Sprintf("Condition[%s]{\n\tType: %q,\n\tStatus: %s,\n\tReason: %q,\n\tMessage: %q,\n\tLastTransitionTime: %v,\n}", reflect.TypeFor[T]().Name(), conType, status, reason, message, lastTransitionTime)
+	return fmt.Sprintf("Condition{\n\tType: %q,\n\tStatus: %s,\n\tObservedGeneration: %s,\n\tReason: %q,\n\tMessage: %q,\n\tLastTransitionTime: %v,\n}", conType, status, observedGeneration, reason, message, lastTransitionTime)
 }
 
-var _ conditions.Condition[bool] = &ConditionImpl[bool]{}
-
-func (c *ConditionImpl[T]) GetLastTransitionTime() time.Time {
-	return *c.lastTransitionTime
+func TestCondition() *Condition {
+	return &Condition{}
 }
 
-func (c *ConditionImpl[T]) GetType() string {
-	return *c.conType
+func TestConditionFromCondition(con metav1.Condition) *Condition {
+	return TestConditionFromValues(con.Type, con.Status, con.ObservedGeneration, con.Reason, con.Message, con.LastTransitionTime)
 }
 
-func (c *ConditionImpl[T]) GetStatus() T {
-	return *c.status
+func TestConditionFromValues(conType string, status metav1.ConditionStatus, observedGeneration int64, reason, message string, lastTransitionTime metav1.Time) *Condition {
+	return TestCondition().
+		WithType(conType).
+		WithStatus(status).
+		WithObservedGeneration(observedGeneration).
+		WithReason(reason).
+		WithMessage(message).
+		WithLastTransitionTime(lastTransitionTime)
 }
 
-func (c *ConditionImpl[T]) GetReason() string {
-	return *c.reason
+func (c *Condition) ToCondition() metav1.Condition {
+	if c == nil {
+		return metav1.Condition{}
+	}
+	res := metav1.Condition{}
+	if c.conType != nil {
+		res.Type = *c.conType
+	}
+	if c.status != nil {
+		res.Status = *c.status
+	} else {
+		res.Status = metav1.ConditionUnknown
+	}
+	if c.observedGeneration != nil {
+		res.ObservedGeneration = *c.observedGeneration
+	}
+	if c.reason != nil {
+		res.Reason = *c.reason
+	}
+	if c.message != nil {
+		res.Message = *c.message
+	}
+	if c.lastTransitionTime != nil {
+		res.LastTransitionTime = *c.lastTransitionTime
+	}
+	return res
 }
 
-func (c *ConditionImpl[T]) GetMessage() string {
-	return *c.message
-}
-
-func (c *ConditionImpl[T]) SetStatus(status T) {
-	c.status = &status
-}
-
-func (c *ConditionImpl[T]) SetType(conType string) {
-	c.conType = &conType
-}
-
-func (c *ConditionImpl[T]) SetLastTransitionTime(timestamp time.Time) {
-	c.lastTransitionTime = &timestamp
-}
-
-func (c *ConditionImpl[T]) SetReason(reason string) {
-	c.reason = &reason
-}
-
-func (c *ConditionImpl[T]) SetMessage(message string) {
-	c.message = &message
-}
-
-func (c *ConditionImpl[T]) HasLastTransitionTime() bool {
-	return c.lastTransitionTime != nil
-}
-
-func (c *ConditionImpl[T]) HasType() bool {
-	return c.conType != nil
-}
-
-func (c *ConditionImpl[T]) HasStatus() bool {
-	return c.status != nil
-}
-
-func (c *ConditionImpl[T]) HasReason() bool {
-	return c.reason != nil
-}
-
-func (c *ConditionImpl[T]) HasMessage() bool {
-	return c.message != nil
-}
-
-func (c *ConditionImpl[T]) WithLastTransitionTime(timestamp time.Time) *ConditionImpl[T] {
-	c.SetLastTransitionTime(timestamp)
+func (c *Condition) WithType(conType string) *Condition {
+	cp := conType
+	c.conType = &cp
 	return c
 }
 
-func (c *ConditionImpl[T]) WithType(conType string) *ConditionImpl[T] {
-	c.SetType(conType)
+func (c *Condition) WithStatus(status metav1.ConditionStatus) *Condition {
+	cp := status
+	c.status = &cp
 	return c
 }
 
-func (c *ConditionImpl[T]) WithStatus(status T) *ConditionImpl[T] {
-	c.SetStatus(status)
+func (c *Condition) WithObservedGeneration(observedGeneration int64) *Condition {
+	cp := observedGeneration
+	c.observedGeneration = &cp
 	return c
 }
 
-func (c *ConditionImpl[T]) WithReason(reason string) *ConditionImpl[T] {
-	c.SetReason(reason)
+func (c *Condition) WithReason(reason string) *Condition {
+	cp := reason
+	c.reason = &cp
 	return c
 }
 
-func (c *ConditionImpl[T]) WithMessage(message string) *ConditionImpl[T] {
-	c.SetMessage(message)
+func (c *Condition) WithMessage(message string) *Condition {
+	cp := message
+	c.message = &cp
 	return c
 }
 
-func (c *ConditionImpl[T]) WithTimestampTolerance(t time.Duration) *ConditionImpl[T] {
+func (c *Condition) WithLastTransitionTime(timestamp metav1.Time) *Condition {
+	cp := timestamp
+	c.lastTransitionTime = &cp
+	return c
+}
+
+func (c *Condition) WithTimestampTolerance(t time.Duration) *Condition {
 	c.timestampTolerance = t
 	return c
 }
 
-func Ptr[T any](v T) *T {
-	return &v
+// Matches checks if the current Condition matches the other Condition.
+// Note that this method is not symmetrical, meaning that a.Matches(b) may yield a different result than b.Matches(a).
+// The reason for this is that nil fields in the receiver Condition are considered "arbitrary" and will match any value in the other Condition.
+// If both Conditions are nil, they match.
+func (c *Condition) Matches(other *Condition) bool {
+	if c == nil && other == nil {
+		return true
+	}
+	if c == nil || other == nil {
+		return false
+	}
+
+	if c.conType != nil && (other.conType == nil || *c.conType != *other.conType) {
+		return false
+	}
+	if c.status != nil && (other.status == nil || *c.status != *other.status) {
+		return false
+	}
+	if c.observedGeneration != nil && (other.observedGeneration == nil || *c.observedGeneration != *other.observedGeneration) {
+		return false
+	}
+	if c.reason != nil && (other.reason == nil || *c.reason != *other.reason) {
+		return false
+	}
+	if c.message != nil && (other.message == nil || *c.message != *other.message) {
+		return false
+	}
+	if c.lastTransitionTime != nil && (other.lastTransitionTime == nil || c.lastTransitionTime.Sub(other.lastTransitionTime.Time) > c.timestampTolerance) {
+		return false
+	}
+
+	return true
 }

--- a/pkg/testing/matchers/conditions_test.go
+++ b/pkg/testing/matchers/conditions_test.go
@@ -1,0 +1,78 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/openmcp-project/controller-utils/pkg/testing/matchers"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("MatchCondition", func() {
+
+	It("should match if expected and actual are nil", func() {
+		Expect(MatchCondition(nil).Match(nil)).To(BeTrue())
+	})
+
+	It("should match if expected and actual are identical", func() {
+		expected := TestConditionFromValues("test", metav1.ConditionTrue, 0, "reason", "message", metav1.Now())
+		Expect(MatchCondition(expected).Match(expected.ToCondition())).To(BeTrue())
+	})
+
+	It("should match if expected is a Condition generated from the actual metav1.Condition", func() {
+		actual := metav1.Condition{
+			Type:               "test",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: 0,
+			Reason:             "reason",
+			Message:            "message",
+			LastTransitionTime: metav1.Now(),
+		}
+		expected := TestConditionFromCondition(actual)
+		Expect(MatchCondition(expected).Match(&actual)).To(BeTrue())
+	})
+
+	It("should match if actual is a metav1.Condition generated from the expected Condition", func() {
+		expected := TestConditionFromValues("test", metav1.ConditionTrue, 0, "reason", "message", metav1.Now())
+		actual := expected.ToCondition()
+		Expect(MatchCondition(expected).Match(actual)).To(BeTrue())
+	})
+
+	It("should match any unset fields in the expected condition", func() {
+		actual := metav1.Condition{
+			Type:               "test",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: 0,
+			Reason:             "reason",
+			Message:            "message",
+			LastTransitionTime: metav1.Now(),
+		}
+
+		Expect(MatchCondition(TestCondition().WithType(actual.Type).WithStatus(actual.Status).WithObservedGeneration(actual.ObservedGeneration).WithReason(actual.Reason).WithMessage(actual.Message).WithLastTransitionTime(actual.LastTransitionTime)).Match(actual)).To(BeTrue())
+		Expect(MatchCondition(TestCondition().WithStatus(actual.Status).WithObservedGeneration(actual.ObservedGeneration).WithReason(actual.Reason).WithMessage(actual.Message).WithLastTransitionTime(actual.LastTransitionTime)).Match(actual)).To(BeTrue())
+		Expect(MatchCondition(TestCondition().WithType(actual.Type).WithObservedGeneration(actual.ObservedGeneration).WithReason(actual.Reason).WithMessage(actual.Message).WithLastTransitionTime(actual.LastTransitionTime)).Match(actual)).To(BeTrue())
+		Expect(MatchCondition(TestCondition().WithType(actual.Type).WithStatus(actual.Status).WithReason(actual.Reason).WithMessage(actual.Message).WithLastTransitionTime(actual.LastTransitionTime)).Match(actual)).To(BeTrue())
+		Expect(MatchCondition(TestCondition().WithType(actual.Type).WithStatus(actual.Status).WithObservedGeneration(actual.ObservedGeneration).WithMessage(actual.Message).WithLastTransitionTime(actual.LastTransitionTime)).Match(actual)).To(BeTrue())
+		Expect(MatchCondition(TestCondition().WithType(actual.Type).WithStatus(actual.Status).WithObservedGeneration(actual.ObservedGeneration).WithReason(actual.Reason).WithLastTransitionTime(actual.LastTransitionTime)).Match(actual)).To(BeTrue())
+		Expect(MatchCondition(TestCondition().WithType(actual.Type).WithStatus(actual.Status).WithObservedGeneration(actual.ObservedGeneration).WithReason(actual.Reason).WithMessage(actual.Message)).Match(actual)).To(BeTrue())
+	})
+
+	It("should match independent of whether actual is a pointer or value", func() {
+		actual := metav1.Condition{
+			Type:               "test",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: 0,
+			Reason:             "reason",
+			Message:            "message",
+			LastTransitionTime: metav1.Now(),
+		}
+		expected := TestConditionFromCondition(actual)
+
+		Expect(MatchCondition(expected).Match(&actual)).To(BeTrue())
+		Expect(MatchCondition(expected).Match(actual)).To(BeTrue())
+		Expect(MatchCondition(expected).Match(expected)).To(BeTrue())
+		Expect(MatchCondition(expected).Match(*expected)).To(BeTrue())
+	})
+
+})

--- a/pkg/testing/matchers/suite_test.go
+++ b/pkg/testing/matchers/suite_test.go
@@ -1,0 +1,14 @@
+package matchers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestComponentUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Matchers Test Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
We decided that all our resources should use the `k8s.io/apimachinery/pkg/apis/meta/v1.Condition` type to display conditions. This PR adapts the condition updater to work with this type instead of using our own `Condition` interface.

**Which issue(s) this PR fixes**:
None, loosely related to https://github.com/openmcp-project/openmcp-operator/issues/70

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
⚠️ The condition updater now uses the `Condition` type from the `k8s.io/apimachinery/pkg/apis/meta/v1` package.
```
