### PR TITLE
fix cluster's Scheme() method in test setups

### DIFF
--- a/pkg/clusters/cluster.go
+++ b/pkg/clusters/cluster.go
@@ -224,10 +224,12 @@ func (c *Cluster) Cluster() cluster.Cluster {
 // Scheme returns the cluster's scheme.
 // Returns nil if the client has not been initialized.
 func (c *Cluster) Scheme() *runtime.Scheme {
-	if c.cluster == nil {
-		return nil
+	if c.cluster != nil {
+		return c.cluster.GetScheme()
+	} else if c.client != nil {
+		return c.client.Scheme()
 	}
-	return c.cluster.GetScheme()
+	return nil
 }
 
 // APIServerEndpoint returns the cluster's API server endpoint.


### PR DESCRIPTION
**What this PR does / why we need it**:
The `Scheme()` method of the `Cluster` type did return `nil`, if the internal `cluster.Cluster` was nil, even if the internal `client.Client` was not and returning a scheme would have been possible. The `NewTestClusterFromClient` constructor which can be used to construct a 'fake' `Cluster` for testing purposes returns exactly a `Cluster` instance where the internal `cluster.Cluster` is nil, but the internal `client.Client` is not.
The old implementation of the `Scheme` method therefore prevents any code from using it if said code is being tested with a `Cluster` constructed with the `NewTestClusterFromClient` function.

This PR fixes the problem by returning the internal `client.Client`'s scheme as a fallback, if the internal `cluster.Cluster` is nil. The `Scheme` method should now only return `nil`, if both, the internal cluster and the internal client, are nil.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Improved the implementation of the `Cluster` type's `Scheme` method so it does not return `nil` for `Cluster`s created via `NewTestClusterFromClient`.
```
