### PR TITLE
fix bug in condition updater

### DIFF
--- a/pkg/conditions/updater_test.go
+++ b/pkg/conditions/updater_test.go
@@ -161,6 +161,16 @@ var _ = Describe("Conditions", func() {
 			Expect(newCon.LastTransitionTime.After(oldCon.LastTransitionTime.Time)).To(BeTrue())
 		})
 
+		It("should not change the last transition time if the same condition is updated multiple times with the last update setting it to the original value again", func() {
+			cons := testConditionSet()
+			oldCon := conditions.GetCondition(cons, "true")
+			updater := conditions.ConditionUpdater(cons, false)
+			updated, changed := updater.UpdateCondition(oldCon.Type, invert(oldCon.Status), oldCon.ObservedGeneration+1, "newReason", "newMessage").
+				UpdateCondition(oldCon.Type, oldCon.Status, oldCon.ObservedGeneration, oldCon.Reason, oldCon.Message).Conditions()
+			Expect(changed).To(BeFalse())
+			Expect(updated).To(ConsistOf(cons))
+		})
+
 		It("should sort the conditions by type", func() {
 			cons := []metav1.Condition{
 				TestConditionFromValues("c", conditions.FromBool(true), 0, "reason", "message", metav1.Now()).ToCondition(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug in the condition updater that could lead to a condition's `LastTransitionTime` wrongfully being updated if the status did not change. The bug would occur if the same condition was updated multiple times, with any update changing the status and the last update reverting it back to the original value.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fixed a bug in the condition updater that could lead to a condition's `LastTransitionTime` wrongfully being updated if the status did not change.
```
