### PR TITLE
feat: add map containment utility functions

### DIFF
--- a/pkg/collections/maps/utils.go
+++ b/pkg/collections/maps/utils.go
@@ -1,6 +1,8 @@
 package maps
 
 import (
+	"reflect"
+
 	"k8s.io/utils/ptr"
 
 	"github.com/openmcp-project/controller-utils/pkg/collections/filters"
@@ -54,6 +56,36 @@ func Intersect[K comparable, V any](source map[K]V, maps ...map[K]V) map[K]V {
 	}
 
 	return res
+}
+
+// ContainsKeysWithValues checks if 'super' is a superset of 'sub', meaning that all keys of 'sub' are also present in 'super' with the same values.
+// Uses reflect.DeepEqual to compare the values, use ContainsMapFunc if you want to use a custom equality function.
+func ContainsKeysWithValues[K comparable, V any](super, sub map[K]V) bool {
+	return ContainsKeysWithValuesFunc(super, sub, func(a, b V) bool {
+		return reflect.DeepEqual(a, b)
+	})
+}
+
+// ContainsKeysWithValuesFunc checks if 'super' is a superset of 'sub', meaning that all keys of 'sub' are also present in 'super' with the same values.
+// The values are compared using the provided equality function.
+// If the equality function returns false for any key-value pair, it returns false.
+func ContainsKeysWithValuesFunc[K comparable, V any](super, sub map[K]V, equal func(a, b V) bool) bool {
+	for k, bv := range sub {
+		if av, ok := super[k]; !ok || !equal(av, bv) {
+			return false
+		}
+	}
+	return true
+}
+
+// ContainsKeys returns true if all given keys are present in the map.
+func ContainsKeys[K comparable, V any](super map[K]V, keys ...K) bool {
+	for _, k := range keys {
+		if _, ok := super[k]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // GetAny returns an arbitrary key-value pair from the map as a pointer to a pairs.Pair.

--- a/pkg/collections/maps/utils_test.go
+++ b/pkg/collections/maps/utils_test.go
@@ -78,4 +78,71 @@ var _ = Describe("Map Utils Tests", func() {
 
 	})
 
+	Context("ContainsKeysWithValues", func() {
+
+		It("should return true if the second map is empty or nil", func() {
+			m1 := map[string]string{"foo": "bar", "bar": "baz"}
+			Expect(maps.ContainsKeysWithValues(m1, nil)).To(BeTrue())
+			Expect(maps.ContainsKeysWithValues(m1, map[string]string{})).To(BeTrue())
+			Expect(maps.ContainsKeysWithValues[string, string](nil, nil)).To(BeTrue())
+		})
+
+		It("should return true if both maps are identical", func() {
+			m1 := map[string]string{"foo": "bar", "bar": "baz"}
+			Expect(maps.ContainsKeysWithValues(m1, m1)).To(BeTrue())
+		})
+
+		It("should return true if the first map contains all keys and values of the second map", func() {
+			m1 := map[string]string{"foo": "bar", "bar": "baz", "baz": "asdf"}
+			m2 := map[string]string{"foo": "bar", "baz": "asdf"}
+			Expect(maps.ContainsKeysWithValues(m1, m2)).To(BeTrue())
+
+			m3 := map[string]string{"bar": "baz"}
+			Expect(maps.ContainsKeysWithValues(m1, m3)).To(BeTrue())
+		})
+
+		It("should return false if the first map contains all keys but has different values", func() {
+			m1 := map[string]string{"foo": "bar", "bar": "baz"}
+			m2 := map[string]string{"foo": "baz", "bar": "baz"}
+			Expect(maps.ContainsKeysWithValues(m1, m2)).To(BeFalse())
+		})
+
+		It("should return false if the first map does not contain all keys of the second map", func() {
+			m1 := map[string]string{"foo": "bar"}
+			m2 := map[string]string{"foo": "bar", "bar": "baz"}
+			Expect(maps.ContainsKeysWithValues(m1, m2)).To(BeFalse())
+		})
+
+		It("should work with a custom equality function", func() {
+			m1 := map[string]string{"foo": "bar", "bar": "baz"}
+			m2 := map[string]string{"foo": "xyz", "bar": "mno"}
+			cmp := func(a, b string) bool {
+				return len(a) == len(b)
+			}
+			Expect(maps.ContainsKeysWithValuesFunc(m1, m2, cmp)).To(BeTrue())
+		})
+
+	})
+
+	Context("ContainsKeys", func() {
+
+		It("should return true if all keys are present", func() {
+			m1 := map[string]string{"foo": "bar", "bar": "baz", "baz": "asdf"}
+			Expect(maps.ContainsKeys(m1, "foo", "bar")).To(BeTrue())
+		})
+
+		It("should return true if no keys are provided", func() {
+			m1 := map[string]string{"foo": "bar", "bar": "baz", "baz": "asdf"}
+			Expect(maps.ContainsKeys(m1)).To(BeTrue())
+			Expect(maps.ContainsKeys[string, string](nil)).To(BeTrue())
+		})
+
+		It("should return false if any key is missing", func() {
+			m1 := map[string]string{"foo": "bar", "bar": "baz", "baz": "asdf"}
+			Expect(maps.ContainsKeys(m1, "foo", "missing")).To(BeFalse())
+			Expect(maps.ContainsKeys(m1, "missing")).To(BeFalse())
+		})
+
+	})
+
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds utility functions for checking if a map is a superset of another map.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `pkg/collections/maps` package now has a `ContainsKeysAndValues` function that checks whether a given map is a superset of another map, meaning all keys of the second map also exist in the first one and they have the same values. There is also a `ContainsKeysAndValuesFunc` function that allows to pass in a custom equality function for the value comparison and a `ContainsKeys` function that checks only for keys and ignores values.
```
