### PR TITLE
add ConditionsToRemove field to ReconcileResult struct

### DIFF
--- a/docs/libs/status.md
+++ b/docs/libs/status.md
@@ -174,6 +174,7 @@ The `ReconcileResult` that is passed into the status updater is expected to cont
 - `Reason` and `Message` can be set to set the status' corresponding fields.
 	- If either one is nil, but `ReconcileError` is not, it will be filled with a value derived from the error.
 - `Conditions` contains the updated conditions. Depending on with which arguments `WithConditionUpdater` was called, the existing conditions will be either updated with these ones (keeping the other ones), or be replaced by them.
+- `ConditionsToRemove` is a list of condition types that should be removed from the conditions. This is mostly useful if the condition updater is used in the 'keep untouched conditions' mode.
 - `Object` contains the object to be updated.
 	- If `Object` is nil, no status update will be performed.
 - `OldObject` holds the version of the object that will be used as a base for constructing the patch during the status update.

--- a/pkg/controller/status_updater.go
+++ b/pkg/controller/status_updater.go
@@ -265,6 +265,11 @@ func (s *statusUpdater[Obj]) UpdateStatus(ctx context.Context, c client.Client, 
 			}
 			cu.UpdateCondition(con.Type, con.Status, gen, con.Reason, con.Message)
 		}
+		if len(rr.ConditionsToRemove) > 0 {
+			for _, conType := range rr.ConditionsToRemove {
+				cu.RemoveCondition(conType)
+			}
+		}
 		newCons, _ := cu.Record(rr.Object).Conditions()
 		SetField(status, s.fieldNames[STATUS_FIELD_CONDITIONS], newCons)
 	}
@@ -416,6 +421,9 @@ type ReconcileResult[Obj client.Object] struct {
 	// Also note that names of conditions are globally unique, so take care to avoid conflicts with other objects.
 	// The lastTransition timestamp of the condition will be overwritten with the current time while updating.
 	Conditions []metav1.Condition
+	// ConditionsToRemove is an optional slice of condition types for which the corresponding conditions should be removed from the status.
+	// This is useful if you want to remove conditions that are no longer relevant.
+	ConditionsToRemove []string
 }
 
 // GenerateCreateConditionFunc returns a function that can be used to add a condition to the given ReconcileResult.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a possibility to remove conditions via the status updater, if the condition updater is used in 'keep untouched conditions' mode.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The status updater's `ReconcileResult` struct now has a `ConditionsToRemove` field that takes a slice of condition types. If the condition updater is configured on the status updater, all conditions with the listed types are removed from the list of conditions.
```
