### PR TITLE
refactor: move smart requeue action into reconcile result

### DIFF
--- a/docs/libs/smartrequeue.md
+++ b/docs/libs/smartrequeue.md
@@ -7,3 +7,5 @@ Use `NewStore` in the constructor of the reconciler. During reconciliation, the 
 - `Never` does not requeue the object
 - `Backoff` requeues the object with an increasing backoff every time it is called on the same object
 - `Reset` requeues the object, but resets the duration to its minimal value
+
+There is also an integration into the [status updater](./status.md) for the smart requeuing logic.

--- a/docs/libs/status.md
+++ b/docs/libs/status.md
@@ -181,3 +181,10 @@ The `ReconcileResult` that is passed into the status updater is expected to cont
 	- If this is nil, `Object` will be used instead.
 	- If this is non-nil, it must not point to the same instance as `Object` - use the `DeepCopy()` function to create a different instance.
 	- All changes to `Object`'s status that are not part to `OldObject`'s status will be included in the patch during the status update. This can be used to inject custom changes to the status into the status update (in addition to the `WithCustomUpdateFunc` mentioned above).
+- `SmartRequeue` contains the requeuing information for the [smart requeuing logic](./smartrequeue.md).
+	- This field has no effect unless `WithSmartRequeue` has been called on the status updater builder.
+	- If `ReconcileError` is not nil, the value has no effect and the smart requeue error logic is used instead.
+	- Valid values are:
+		- `Backoff` to requeue the object with an increasing backoff
+		- `Reset` to requeue the object, but reset the backoff interval to its minimum
+		- `NoRequeue` to not requeue the object

--- a/pkg/controller/status_updater_test.go
+++ b/pkg/controller/status_updater_test.go
@@ -196,13 +196,14 @@ var _ = Describe("Status Updater", func() {
 			obj := &CustomObject{}
 			Expect(env.Client().Get(env.Ctx, controller.ObjectKey("status", "default"), obj)).To(Succeed())
 			rr := controller.ReconcileResult[*CustomObject]{
-				Object:     obj,
-				Conditions: dummyConditions(),
+				Object:       obj,
+				Conditions:   dummyConditions(),
+				SmartRequeue: controller.SR_RESET,
 			}
 			store := smartrequeue.NewStore(1*time.Second, 10*time.Second, 2.0)
 			su := preconfiguredStatusUpdaterBuilder().WithPhaseUpdateFunc(func(obj *CustomObject, rr controller.ReconcileResult[*CustomObject]) (string, error) {
 				return PhaseSucceeded, nil
-			}).WithSmartRequeue(store, controller.SR_RESET).Build()
+			}).WithSmartRequeue(store).Build()
 			res, err := su.UpdateStatus(env.Ctx, env.Client(), rr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.RequeueAfter).To(Equal(1 * time.Second))
@@ -218,11 +219,12 @@ var _ = Describe("Status Updater", func() {
 				Result: ctrl.Result{
 					RequeueAfter: 30 * time.Second,
 				},
+				SmartRequeue: controller.SR_RESET,
 			}
 			store := smartrequeue.NewStore(1*time.Second, 10*time.Second, 2.0)
 			su := preconfiguredStatusUpdaterBuilder().WithPhaseUpdateFunc(func(obj *CustomObject, rr controller.ReconcileResult[*CustomObject]) (string, error) {
 				return PhaseSucceeded, nil
-			}).WithSmartRequeue(store, controller.SR_RESET).Build()
+			}).WithSmartRequeue(store).Build()
 			res, err := su.UpdateStatus(env.Ctx, env.Client(), rr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.RequeueAfter).To(Equal(1 * time.Second))
@@ -231,7 +233,7 @@ var _ = Describe("Status Updater", func() {
 			store = smartrequeue.NewStore(1*time.Minute, 10*time.Minute, 2.0)
 			su = preconfiguredStatusUpdaterBuilder().WithPhaseUpdateFunc(func(obj *CustomObject, rr controller.ReconcileResult[*CustomObject]) (string, error) {
 				return PhaseSucceeded, nil
-			}).WithSmartRequeue(store, controller.SR_RESET).Build()
+			}).WithSmartRequeue(store).Build()
 			res, err = su.UpdateStatus(env.Ctx, env.Client(), rr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.RequeueAfter).To(Equal(30 * time.Second))


### PR DESCRIPTION
**What this PR does / why we need it**:
Moved the field to a place where it makes more sense.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The information, how the object should be requeued when the smart requeuing logic is used with the status updater integration has been moved from the `WithSmartRequeue` call into the `ReconcileResult`.
```
