### PR TITLE
feat: add function to generate oidc-based kubeconfig

### DIFF
--- a/pkg/clusteraccess/access_test.go
+++ b/pkg/clusteraccess/access_test.go
@@ -490,24 +490,27 @@ var _ = Describe("ClusterAccess", func() {
 		})
 
 		It("should create a kubeconfig with oidc-login plugin (all options)", func() {
+			contextId := "my-context"
+			clusterId := "my-cluster"
 			kcfgBytes, err := clusteraccess.CreateOIDCKubeconfig("testuser", "https://api.example.com", []byte("test-ca"), "https://example.com/oidc", "test-client-id",
 				clusteraccess.WithExtraScope("foo"),
 				clusteraccess.WithExtraScope("bar"),
 				clusteraccess.UsePKCE(),
 				clusteraccess.ForceRefresh(),
 				clusteraccess.WithClientSecret("test-client-secret"),
-				clusteraccess.WithGrantType(clusteraccess.GrantTypePassword))
+				clusteraccess.WithGrantType(clusteraccess.GrantTypePassword),
+				clusteraccess.WithContextName(contextId),
+				clusteraccess.WithClusterName(clusterId))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kcfgBytes).ToNot(BeEmpty())
 
 			kcfg, err := clientcmd.Load(kcfgBytes)
 			Expect(err).ToNot(HaveOccurred())
-			id := "cluster"
-			Expect(kcfg.CurrentContext).To(Equal(id))
-			Expect(kcfg.Contexts[id].Cluster).To(Equal(id))
-			Expect(kcfg.Contexts[id].AuthInfo).To(Equal("testuser"))
-			Expect(kcfg.Clusters[id].Server).To(Equal("https://api.example.com"))
-			Expect(kcfg.Clusters[id].CertificateAuthorityData).To(Equal([]byte("test-ca")))
+			Expect(kcfg.CurrentContext).To(Equal(contextId))
+			Expect(kcfg.Contexts[contextId].Cluster).To(Equal(clusterId))
+			Expect(kcfg.Contexts[contextId].AuthInfo).To(Equal("testuser"))
+			Expect(kcfg.Clusters[clusterId].Server).To(Equal("https://api.example.com"))
+			Expect(kcfg.Clusters[clusterId].CertificateAuthorityData).To(Equal([]byte("test-ca")))
 			auth := kcfg.AuthInfos["testuser"]
 			Expect(auth).ToNot(BeNil())
 			Expect(auth.Exec).ToNot(BeNil())

--- a/pkg/clusteraccess/access_test.go
+++ b/pkg/clusteraccess/access_test.go
@@ -462,4 +462,69 @@ var _ = Describe("ClusterAccess", func() {
 		})
 	})
 
+	Context("CreateOIDCKubeconfig", func() {
+
+		It("should create a kubeconfig with oidc-login plugin (no options)", func() {
+			kcfgBytes, err := clusteraccess.CreateOIDCKubeconfig("testuser", "https://api.example.com", []byte("test-ca"), "https://example.com/oidc", "test-client-id")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kcfgBytes).ToNot(BeEmpty())
+
+			kcfg, err := clientcmd.Load(kcfgBytes)
+			Expect(err).ToNot(HaveOccurred())
+			id := "cluster"
+			Expect(kcfg.CurrentContext).To(Equal(id))
+			Expect(kcfg.Contexts[id].Cluster).To(Equal(id))
+			Expect(kcfg.Contexts[id].AuthInfo).To(Equal("testuser"))
+			Expect(kcfg.Clusters[id].Server).To(Equal("https://api.example.com"))
+			Expect(kcfg.Clusters[id].CertificateAuthorityData).To(Equal([]byte("test-ca")))
+			auth := kcfg.AuthInfos["testuser"]
+			Expect(auth).ToNot(BeNil())
+			Expect(auth.Exec).ToNot(BeNil())
+			Expect(auth.Exec.Command).To(Equal("kubectl"))
+			Expect(auth.Exec.Args[:2]).To(Equal([]string{"oidc-login", "get-token"}))
+			Expect(auth.Exec.Args[2:]).To(ConsistOf(
+				"--oidc-issuer-url=https://example.com/oidc",
+				"--oidc-client-id=test-client-id",
+				"--grant-type=auto",
+			))
+		})
+
+		It("should create a kubeconfig with oidc-login plugin (all options)", func() {
+			kcfgBytes, err := clusteraccess.CreateOIDCKubeconfig("testuser", "https://api.example.com", []byte("test-ca"), "https://example.com/oidc", "test-client-id",
+				clusteraccess.WithExtraScope("foo"),
+				clusteraccess.WithExtraScope("bar"),
+				clusteraccess.UsePKCE(),
+				clusteraccess.ForceRefresh(),
+				clusteraccess.WithClientSecret("test-client-secret"),
+				clusteraccess.WithGrantType(clusteraccess.GrantTypePassword))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kcfgBytes).ToNot(BeEmpty())
+
+			kcfg, err := clientcmd.Load(kcfgBytes)
+			Expect(err).ToNot(HaveOccurred())
+			id := "cluster"
+			Expect(kcfg.CurrentContext).To(Equal(id))
+			Expect(kcfg.Contexts[id].Cluster).To(Equal(id))
+			Expect(kcfg.Contexts[id].AuthInfo).To(Equal("testuser"))
+			Expect(kcfg.Clusters[id].Server).To(Equal("https://api.example.com"))
+			Expect(kcfg.Clusters[id].CertificateAuthorityData).To(Equal([]byte("test-ca")))
+			auth := kcfg.AuthInfos["testuser"]
+			Expect(auth).ToNot(BeNil())
+			Expect(auth.Exec).ToNot(BeNil())
+			Expect(auth.Exec.Command).To(Equal("kubectl"))
+			Expect(auth.Exec.Args[:2]).To(Equal([]string{"oidc-login", "get-token"}))
+			Expect(auth.Exec.Args[2:]).To(ConsistOf(
+				"--oidc-issuer-url=https://example.com/oidc",
+				"--oidc-client-id=test-client-id",
+				"--oidc-client-secret=test-client-secret",
+				"--grant-type=password",
+				"--oidc-extra-scope=foo",
+				"--oidc-extra-scope=bar",
+				"--oidc-use-pkce",
+				"--force-refresh",
+			))
+		})
+
+	})
+
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a helper function to generate an OIDC-based kubeconfig for human users.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `pkg/clusteraccess` package now contains a `CreateOIDCKubeconfig` function that can be used to generate a kubeconfig that uses the `oidc-login` kubectl plugin to authenticate via OIDC.
```
