### PR TITLE
feat: new hash function for k8s resource names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
+	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.38.0
 	github.com/openmcp-project/controller-utils/api v0.17.0
@@ -44,7 +45,6 @@ require (
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect

--- a/pkg/controller/hash_test.go
+++ b/pkg/controller/hash_test.go
@@ -1,0 +1,134 @@
+package controller
+
+import (
+	"crypto/sha3"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Test_Version8UUID(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		data        []byte
+		expectedErr *string
+	}{
+		{
+			desc: "Text1",
+			data: sha3.SumSHAKE128([]byte("hello world"), 16),
+		},
+		{
+			desc: "Text2",
+			data: sha3.SumSHAKE128([]byte("The quick brown fox jumps over the lazy dog"), 16),
+		},
+		{
+			desc: "Text3",
+			data: sha3.SumSHAKE128([]byte("Lorem ipsum dolor sit amet"), 16),
+		},
+		{
+			desc:        "TooShort",
+			data:        sha3.SumSHAKE128([]byte("Lorem ipsum dolor sit amet"), 15),
+			expectedErr: ptr.To("invalid data (got 15 bytes)"),
+		},
+		{
+			desc:        "TooLong",
+			data:        sha3.SumSHAKE128([]byte("Lorem ipsum dolor sit amet"), 17),
+			expectedErr: ptr.To("invalid data (got 17 bytes)"),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			u, err := Version8UUID(tC.data)
+			if tC.expectedErr == nil {
+				assert.NoError(t, err)
+				assert.Equal(t, uuid.Version(8), u.Version(), "unexpected version")
+				assert.Equal(t, uuid.RFC4122, u.Variant(), "unexpected variant")
+			} else {
+				assert.EqualError(t, err, *tC.expectedErr)
+				assert.Equal(t, uuid.Nil, u)
+			}
+		})
+	}
+}
+
+func Test_K8sNameUUID(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		input        []string
+		expectedUUID string
+		expectedErr  error
+	}{
+		{
+			desc:         "should generate ID from one name",
+			input:        []string{"example"},
+			expectedUUID: "23cc2129-a257-8644-95e0-289d55c69704",
+		},
+		{
+			desc:         "should generate ID from two names",
+			input:        []string{corev1.NamespaceDefault, "example"},
+			expectedUUID: "2bcf790e-815e-8ea9-857b-15be429583a5",
+		},
+		{
+			desc:        "should fail because of empty slice",
+			input:       []string{},
+			expectedErr: ErrInvalidNames,
+		},
+		{
+			desc:        "should fail because of slice with empty string",
+			input:       []string{""},
+			expectedErr: ErrInvalidNames,
+		},
+		{
+			desc:        "should fail because of slice with empty strings",
+			input:       []string{"", ""},
+			expectedErr: ErrInvalidNames,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			actual, err := K8sNameUUID(tC.input...)
+			assert.Equal(t, tC.expectedUUID, actual)
+			assert.Equal(t, tC.expectedErr, err)
+		})
+	}
+}
+
+func Test_K8sObjectUUID(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		obj          client.Object
+		expectedUUID string
+	}{
+		{
+			desc: "should work with config map",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example",
+					Namespace: "default",
+				},
+			},
+			expectedUUID: "2bcf790e-815e-8ea9-857b-15be429583a5", // same as in Test_K8sNameUUID
+		},
+		{
+			desc: "should work with config map and empty namespace",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example",
+				},
+			},
+			expectedUUID: "2bcf790e-815e-8ea9-857b-15be429583a5", // same as above
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			actual, err := K8sObjectUUID(tC.obj)
+			assert.NoError(t, err)
+			assert.Equal(t, tC.expectedUUID, actual)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds new functions to generate a hash (in UUID v8 format) for Kubernetes resource names. It uses SHAKE128 (SHA-3) internally which is FIPS 202 compliant.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
feat: new hash function for k8s resource names
```
