### PR TITLE
feat: add unsafe k8s uuid functions

### DIFF
--- a/pkg/controller/hash.go
+++ b/pkg/controller/hash.go
@@ -61,6 +61,16 @@ func validateIDs(names []string) error {
 	return ErrInvalidNames
 }
 
+// K8sNameUUIDUnsafe works like K8sNameUUID, but panics instead of returning an error.
+// This should only be used in places where the input is guaranteed to be valid.
+func K8sNameUUIDUnsafe(names ...string) string {
+	uuid, err := K8sNameUUID(names...)
+	if err != nil {
+		panic(err)
+	}
+	return uuid
+}
+
 // K8sObjectUUID takes a client object and computes a hash out of the namespace and name, which is then formatted as a version 8 UUID.
 // An empty namespace will be replaced by "default".
 func K8sObjectUUID(obj client.Object) (string, error) {
@@ -69,4 +79,14 @@ func K8sObjectUUID(obj client.Object) (string, error) {
 		namespace = corev1.NamespaceDefault
 	}
 	return K8sNameUUID(namespace, name)
+}
+
+// K8sObjectUUIDUnsafe works like K8sObjectUUID, but panics instead of returning an error.
+// This should only be used in places where the input is guaranteed to be valid.
+func K8sObjectUUIDUnsafe(obj client.Object) string {
+	uuid, err := K8sObjectUUID(obj)
+	if err != nil {
+		panic(err)
+	}
+	return uuid
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
#114 added new hash functions for generating k8s resource names, but opposed to the old ones, they return not only a string, but also an error. To make using the new functions easier in cases where the input is known to be valid, this PR adds 'unsafe' variants for the functions which panic instead of returning an error.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Added `K8sNameUUIDUnsafe` and `K8sObjectUUIDUnsafe` alternatives for the `K8sNameUUID` and `K8sObjectUUID` functions that panic instead of returning an error.
```
