### PR TITLE
feat: enable skipping clusters in CRD management

### DIFF
--- a/pkg/crds/crds_test.go
+++ b/pkg/crds/crds_test.go
@@ -31,7 +31,7 @@ var _ = Describe("CRDsFromFileSystem", func() {
 		crdPath := "testdata"
 		crdsList, err := crds.CRDsFromFileSystem(testFS, crdPath)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(crdsList).To(HaveLen(2))
+		Expect(crdsList).To(HaveLen(3))
 
 		// Validate the first CRD
 		Expect(crdsList[0].Name).To(Equal("testresources.example.com"))
@@ -68,6 +68,11 @@ var _ = Describe("CRDManager", func() {
 		crdManager.AddCRDLabelToClusterMapping("cluster_b", clusterB)
 
 		ctx := context.Background()
+
+		// CRD creation should fail due to unknown cluster label
+		Expect(crdManager.CreateOrUpdateCRDs(ctx, nil)).To(HaveOccurred())
+
+		crdManager.SkipCRDsWithClusterLabel("cluster_c")
 
 		err = crdManager.CreateOrUpdateCRDs(ctx, nil)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/crds/testdata/crd_c.yaml
+++ b/pkg/crds/testdata/crd_c.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: unused.example.com
+  labels:
+    openmcp.cloud/cluster: "cluster_c"
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    listKind: TestResourceList
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables skipping Clusters when applying CRDs via the CRD management.

**Which issue(s) this PR fixes**:
Loosely related to https://github.com/openmcp-project/backlog/issues/210

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
It is now possible to skip Clusters when using the CRD Management to create/update CRDs.
```
