### PR TITLE
fix: avoid invalid condition reasons

### DIFF
--- a/pkg/conditions/updater.go
+++ b/pkg/conditions/updater.go
@@ -90,7 +90,8 @@ func (c *conditionUpdater) WithEventRecorder(recorder record.EventRecorder, verb
 func (c *conditionUpdater) UpdateCondition(conType string, status metav1.ConditionStatus, observedGeneration int64, reason, message string) *conditionUpdater {
 	if reason == "" {
 		// the metav1.Condition type requires a reason, so let's add a dummy if none is given
-		reason = conType + string(status)
+		// the type field allows dots ('.'), while the reason field does not, so replace them with colons (':') (which are not allowed in the type field)
+		reason = strings.ReplaceAll(conType, ".", ":") + "_" + string(status)
 	}
 	con := metav1.Condition{
 		Type:               conType,

--- a/pkg/conditions/updater_test.go
+++ b/pkg/conditions/updater_test.go
@@ -223,6 +223,26 @@ var _ = Describe("Conditions", func() {
 			Expect(updater.HasCondition("true")).To(BeTrue())
 		})
 
+		It("should correctly add a reason if not given and replace invalid characters from the type", func() {
+			cons := []metav1.Condition{}
+			updated, _ := conditions.ConditionUpdater(cons, false).
+				UpdateCondition("TestCondition", conditions.FromBool(true), 0, "", "").
+				UpdateCondition("TestCondition.Test", conditions.FromBool(false), 0, "", "").
+				Conditions()
+			Expect(updated).To(ConsistOf(
+				MatchCondition(TestCondition().
+					WithType("TestCondition").
+					WithStatus(metav1.ConditionTrue).
+					WithReason("TestCondition_True").
+					WithMessage("")),
+				MatchCondition(TestCondition().
+					WithType("TestCondition.Test").
+					WithStatus(metav1.ConditionFalse).
+					WithReason("TestCondition:Test_False").
+					WithMessage("")),
+			))
+		})
+
 	})
 
 	Context("EventRecorder", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
We use the k8s default `Condition` type, which not only requires a non-empty `Reason`, but also validates it against a regex. To avoid issues, the ConditionUpdater just added a dummy reason if it was empty, for which it used the condition's `Type`. The regex for type and reason differ, though: type allows `.` but not `:`, while for the reason,  it is the other way around.

This PR replaces `.` with `:` when using the type default the condition reason.

**Which issue(s) this PR fixes**:
Required for https://github.com/openmcp-project/openmcp-operator/pull/115
(not a hard requirement, though, there is a workaround in place)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The condition updater would produce an invalid dummy reason for a condition if that condition's type contained a `.`, because this is not an allowed character in the condition's reason. This is now avoided by replacing `.` with `:` when using the condition's type to construct a dummy reason.
```
