### PR TITLE
feat: add constant for k8s max name length

### DIFF
--- a/pkg/controller/hash.go
+++ b/pkg/controller/hash.go
@@ -17,6 +17,9 @@ var (
 	ErrMaxLenTooSmall = errors.New("maxLen must be greater than 10")
 )
 
+// K8sMaxNameLength is the maximum length for Kubernetes resource names.
+const K8sMaxNameLength = 63
+
 // version8UUID creates a new UUID (version 8) from a byte slice. Returns an error if the slice does not have a length of 16. The bytes are copied from the slice.
 // The bits 48-51 and 64-65 are modified to make the output recognizable as a version 8 UUID, so only 122 out of 128 bits from the input data will be kept.
 func version8UUID(data []byte) (uuid.UUID, error) {
@@ -135,4 +138,14 @@ func ShortenToXCharacters(input string, maxLen int) (string, error) {
 	}
 
 	return input[:trimLength] + suffix, nil
+}
+
+// ShortenToXCharactersUnsafe works like ShortenToXCharacters, but panics instead of returning an error.
+// This should only be used in places where the input is guaranteed to be valid.
+func ShortenToXCharactersUnsafe(input string, maxLen int) string {
+	result, err := ShortenToXCharacters(input, maxLen)
+	if err != nil {
+		panic(err)
+	}
+	return result
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a constant for the maximum k8s name length. This is useful for the shorten function. Also adds a shorten function that does not return an error, but panics instead.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `pkg/controller` package now has a constant `K8sMaxNameLength` that holds the maximum length for k8s resource names. This is useful in combination with the package's `ShortenToXCharacters` function.
```
```feature developer
In addition to the `pkg/controller` package's `ShortenToXCharacters` function, there is now also a `ShortenToXCharactersUnsafe` function which panics instead of returning an error if something goes wrong.
```
