### PR TITLE
feat: add exact name predicate

### DIFF
--- a/pkg/controller/predicates.go
+++ b/pkg/controller/predicates.go
@@ -217,3 +217,17 @@ func (p StatusChangedPredicate) Update(e event.UpdateEvent) bool {
 	}
 	return !reflect.DeepEqual(oldStatus, newStatus)
 }
+
+////////////////////////////////////
+/// IDENTITY MATCHING PREDICATES ///
+////////////////////////////////////
+
+// ExactNamePredicate returns true if the object's name and namespace exactly match the specified values.
+func ExactNamePredicate(name, namespace string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		if obj == nil {
+			return false
+		}
+		return obj.GetName() == name && obj.GetNamespace() == namespace
+	})
+}

--- a/pkg/controller/predicates.go
+++ b/pkg/controller/predicates.go
@@ -223,11 +223,12 @@ func (p StatusChangedPredicate) Update(e event.UpdateEvent) bool {
 ////////////////////////////////////
 
 // ExactNamePredicate returns true if the object's name and namespace exactly match the specified values.
+// The namespace can be set to '*' to match any namespace.
 func ExactNamePredicate(name, namespace string) predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if obj == nil {
 			return false
 		}
-		return obj.GetName() == name && obj.GetNamespace() == namespace
+		return obj.GetName() == name && (namespace == "*" || obj.GetNamespace() == namespace)
 	})
 }

--- a/pkg/controller/predicates_test.go
+++ b/pkg/controller/predicates_test.go
@@ -234,6 +234,22 @@ var _ = Describe("Predicates", func() {
 
 	})
 
+	Context("Identity", func() {
+
+		It("should match resources with the specified identity", func() {
+			p := ctrlutils.ExactNamePredicate("foo", "bar")
+			e := event.CreateEvent{Object: base}
+			Expect(p.Create(e)).To(BeTrue())
+
+			p2 := ctrlutils.ExactNamePredicate("foo", "")
+			Expect(p2.Create(e)).To(BeFalse())
+
+			p3 := ctrlutils.ExactNamePredicate("foo", "baz")
+			Expect(p3.Create(e)).To(BeFalse())
+		})
+
+	})
+
 })
 
 func updateEvent(old, new client.Object) event.UpdateEvent {

--- a/pkg/controller/predicates_test.go
+++ b/pkg/controller/predicates_test.go
@@ -246,6 +246,9 @@ var _ = Describe("Predicates", func() {
 
 			p3 := ctrlutils.ExactNamePredicate("foo", "baz")
 			Expect(p3.Create(e)).To(BeFalse())
+
+			p4 := ctrlutils.ExactNamePredicate("foo", "*")
+			Expect(p4.Create(e)).To(BeTrue())
 		})
 
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a predicate that allows to filter for a specific name and namespace. Might be useful for some of our providers that read only a single provider configuration resource.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `pkg/controller` library now has an `ExactNamePredicate` that allows to filter for a specific name and namespace.
```
