### PR TITLE
feat: add predicates for each specific type of event

### DIFF
--- a/pkg/controller/predicates.go
+++ b/pkg/controller/predicates.go
@@ -232,3 +232,63 @@ func ExactNamePredicate(name, namespace string) predicate.Predicate {
 		return obj.GetName() == name && (namespace == "*" || obj.GetNamespace() == namespace)
 	})
 }
+
+/////////////////////////////
+/// EVENT TYPE PREDICATES ///
+/////////////////////////////
+
+type EventType string
+
+const (
+	CreateEvent  EventType = "create"
+	UpdateEvent  EventType = "update"
+	DeleteEvent  EventType = "delete"
+	GenericEvent EventType = "generic"
+)
+
+type eventTypePredicate struct {
+	eventType EventType
+}
+
+var _ predicate.Predicate = eventTypePredicate{}
+
+func (e eventTypePredicate) Create(_ event.TypedCreateEvent[client.Object]) bool {
+	return e.eventType == CreateEvent
+}
+
+func (e eventTypePredicate) Delete(_ event.TypedDeleteEvent[client.Object]) bool {
+	return e.eventType == DeleteEvent
+}
+
+func (e eventTypePredicate) Update(_ event.TypedUpdateEvent[client.Object]) bool {
+	return e.eventType == UpdateEvent
+}
+
+func (e eventTypePredicate) Generic(_ event.TypedGenericEvent[client.Object]) bool {
+	return e.eventType == GenericEvent
+}
+
+// OnCreatePredicate returns a predicate that reacts only to create events.
+func OnCreatePredicate() predicate.Predicate {
+	return OnEventTypePredicate(CreateEvent)
+}
+
+// OnUpdatePredicate returns a predicate that reacts only to update events.
+func OnUpdatePredicate() predicate.Predicate {
+	return OnEventTypePredicate(UpdateEvent)
+}
+
+// OnDeletePredicate returns a predicate that reacts only to delete events.
+func OnDeletePredicate() predicate.Predicate {
+	return OnEventTypePredicate(DeleteEvent)
+}
+
+// OnGenericPredicate returns a predicate that reacts only to generic events.
+func OnGenericPredicate() predicate.Predicate {
+	return OnEventTypePredicate(GenericEvent)
+}
+
+// OnEventTypePredicate returns a predicate that reacts only to events of the specified type.
+func OnEventTypePredicate(eventType EventType) predicate.Predicate {
+	return eventTypePredicate{eventType: eventType}
+}

--- a/pkg/controller/predicates_test.go
+++ b/pkg/controller/predicates_test.go
@@ -253,6 +253,42 @@ var _ = Describe("Predicates", func() {
 
 	})
 
+	Context("Event Types", func() {
+
+		It("should match only create events", func() {
+			p := ctrlutils.OnCreatePredicate()
+			Expect(p.Create(event.TypedCreateEvent[client.Object]{})).To(BeTrue())
+			Expect(p.Update(event.TypedUpdateEvent[client.Object]{})).To(BeFalse())
+			Expect(p.Delete(event.TypedDeleteEvent[client.Object]{})).To(BeFalse())
+			Expect(p.Generic(event.GenericEvent{})).To(BeFalse())
+		})
+
+		It("should match only update events", func() {
+			p := ctrlutils.OnUpdatePredicate()
+			Expect(p.Create(event.TypedCreateEvent[client.Object]{})).To(BeFalse())
+			Expect(p.Update(event.TypedUpdateEvent[client.Object]{})).To(BeTrue())
+			Expect(p.Delete(event.TypedDeleteEvent[client.Object]{})).To(BeFalse())
+			Expect(p.Generic(event.GenericEvent{})).To(BeFalse())
+		})
+
+		It("should match only delete events", func() {
+			p := ctrlutils.OnDeletePredicate()
+			Expect(p.Create(event.TypedCreateEvent[client.Object]{})).To(BeFalse())
+			Expect(p.Update(event.TypedUpdateEvent[client.Object]{})).To(BeFalse())
+			Expect(p.Delete(event.TypedDeleteEvent[client.Object]{})).To(BeTrue())
+			Expect(p.Generic(event.GenericEvent{})).To(BeFalse())
+		})
+
+		It("should match only generic events", func() {
+			p := ctrlutils.OnGenericPredicate()
+			Expect(p.Create(event.TypedCreateEvent[client.Object]{})).To(BeFalse())
+			Expect(p.Update(event.TypedUpdateEvent[client.Object]{})).To(BeFalse())
+			Expect(p.Delete(event.TypedDeleteEvent[client.Object]{})).To(BeFalse())
+			Expect(p.Generic(event.GenericEvent{})).To(BeTrue())
+		})
+
+	})
+
 })
 
 func updateEvent(old, new client.Object) event.UpdateEvent {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds predicates that allow to filter for specific event types.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `pkg/controller` library now contains the following new predicates:
- OnCreatePredicate() reacts only on create events
- OnDeletePredicate() reacts only on delete events
- OnUpdatePredicate() reacts only on update events
- OnGenericPredicate() reacts only on generic events
- OnEventTypePredicate(eventType) allows to pass in the event type dynamically
```
