### PR TITLE
docs(resources): clarify Secret.Type behavior in Mutate()

### DIFF
--- a/pkg/resources/secret.go
+++ b/pkg/resources/secret.go
@@ -67,6 +67,8 @@ func (m *SecretMutator) Empty() *core.Secret {
 	return s
 }
 
+// Mutate sets the Type field explicitly to ensure correctness with CreateOrUpdate patterns.
+// Kubernetes does not enforce Secret.Type as immutable (see pkg/registry/core/secret/strategy.go).
 func (m *SecretMutator) Mutate(s *core.Secret) error {
 	s.Type = m.Type
 	if m.Data != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a brief comment to `SecretMutator.Mutate()` explaining why Type is set explicitly.

Follow-up to #225 addressing reviewer feedback about Secret.Type behavior.

**Which issue(s) this PR fixes**:
N/A - documentation only

**Special notes for your reviewer**:

Kubernetes does not enforce `Secret.Type` as immutable (`pkg/registry/core/secret/strategy.go`).

**Release note**:
```doc developer
Clarified Secret.Type handling in SecretMutator.Mutate()
```