### PR TITLE
feat: add aliases for smartrequeue functions

### DIFF
--- a/pkg/controller/smartrequeue/entry.go
+++ b/pkg/controller/smartrequeue/entry.go
@@ -40,12 +40,24 @@ func (e *Entry) IsStable() (ctrl.Result, error) {
 	return ctrl.Result{RequeueAfter: current}, nil
 }
 
+// RequeueWithBackoff requeues after the current interval and increases the interval for the next call.
+// It is an alias for IsStable.
+func (e *Entry) RequeueWithBackoff() (ctrl.Result, error) {
+	return e.IsStable()
+}
+
 // IsProgressing indicates the resource is actively changing. It resets the backoff
 // to minInterval and requeues after that interval.
 func (e *Entry) IsProgressing() (ctrl.Result, error) {
 	e.nextDuration = e.store.minInterval
 	defer e.setNext()
 	return ctrl.Result{RequeueAfter: e.nextDuration}, nil
+}
+
+// RequeueWithReset requeues after the minimum interval and resets the backoff for the next call.
+// It is an alias for IsProgressing.
+func (e *Entry) RequeueWithReset() (ctrl.Result, error) {
+	return e.IsProgressing()
 }
 
 // StopRequeue removes the entry from the store and returns an empty result,


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a convenience feature for developers. The smart requeue functionality was originally implemented with requeuing processing resources immediately and 'stable' resources with an increasing backoff. However, we have multiple controllers which don't use the library this way, making the naming of the functions `IsProgressing` and `IsStable` really unintuitive, sometimes even counter-intuitive. This PR adds aliases for both functions to address this problem.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The smart requeue library now allows to use `RequeueWithBackoff` as an alias for `IsStable` and `RequeueWithReset` as an alias for `IsProgressing`. This is meant to cause less confusion when using the library in a different context than it was originally built for.
```
