### PR TITLE
feat: improve logging metadata in testing environment

### DIFF
--- a/pkg/testing/complex_environment.go
+++ b/pkg/testing/complex_environment.go
@@ -259,7 +259,7 @@ func (eb *ComplexEnvironmentBuilder) WithReconciler(name string, reconciler reco
 	if !ok {
 		eb.Reconcilers[name] = &ReconcilerEnvironment{}
 	}
-	eb.Reconcilers[name].Reconciler = reconciler
+	eb.Reconcilers[name].Reconciler = WrapReconcilerWithLoggingMetadata(name, reconciler)
 	return eb
 }
 
@@ -271,7 +271,9 @@ func (eb *ComplexEnvironmentBuilder) WithReconcilerConstructor(name string, cons
 	if !ok {
 		eb.Reconcilers[name] = &ReconcilerEnvironment{}
 	}
-	eb.Reconcilers[name].ReconcilerConstructor = constructor
+	eb.Reconcilers[name].ReconcilerConstructor = func(c ...client.Client) reconcile.Reconciler {
+		return WrapReconcilerWithLoggingMetadata(name, constructor(c...))
+	}
 	eb.Reconcilers[name].Targets = targets
 	return eb
 }
@@ -319,9 +321,12 @@ func (eb *ComplexEnvironmentBuilder) Build() *ComplexEnvironment {
 
 	// initialize logger
 	if !eb.loggerIsSet {
-		log, err := logging.GetLogger()
+		log, err := logging.New(&logging.Config{
+			Development: true,
+			Cli:         true,
+		})
 		if err != nil {
-			panic(fmt.Errorf("error getting logger: %w", err))
+			panic(fmt.Errorf("error creating logger: %w", err))
 		}
 		res.Log = log
 	}
@@ -453,4 +458,34 @@ func InjectUIDOnObjectCreation(additionalLogic func(ctx context.Context, client 
 		}
 		return client.Create(ctx, obj, opts...)
 	}
+}
+
+// WrapReconcilerWithLoggingMetadata wraps the given reconciler with a helper struct that injects additional metadata into the context's logger when 'Reconcile' is called.
+// This mimics the controller-runtime's behavior of adding additional metadata to the logger, such as name and namespace of the reconciled object.
+// This function is applied to all reconcilers that are passed into the builder's 'WithReconciler' or 'WithReconcilerConstructor' methods, so it usually does not need to be called manually.
+func WrapReconcilerWithLoggingMetadata(name string, reconciler reconcile.Reconciler) reconcile.Reconciler {
+	if _, ok := reconciler.(*reconcilerWithLoggingMetadata); ok {
+		// avoid double-wrapping
+		return reconciler
+	}
+	return &reconcilerWithLoggingMetadata{
+		name:     name,
+		internal: reconciler,
+	}
+}
+
+type reconcilerWithLoggingMetadata struct {
+	name     string
+	internal reconcile.Reconciler
+}
+
+var _ reconcile.Reconciler = (*reconcilerWithLoggingMetadata)(nil)
+
+func (r *reconcilerWithLoggingMetadata) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log, err := logging.FromContext(ctx)
+	if err == nil {
+		log = log.WithValues("controller", r.name, "namespace", req.Namespace, "name", req.Name, "reconcileID", string(uuid.NewUUID()))
+		ctx = logging.NewContext(ctx, log)
+	}
+	return r.internal.Reconcile(ctx, req)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
controller-runtime injects several values into the logger contained in the context, most notably a reconcile id and the reconciled object's name and namespace. The testing environment now mimics this behavior, so that log outputs during testing look similarly to the controller's regular ones. In addition, logs during testing are now printed at debug verbosity by default, using a CLI-friendly formatting.

**Which issue(s) this PR fixes**:
Nothing in particular.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Log outputs that come from any reconciler retrieved via the testing environment now log at debug verbosity by default and contain additional metadata (reconcile id, reconciled object's name and namespace, controller name). Note that this only works if the reconciler was added to the testing environment via the builder's `WithReconciler` or `WithReconcilerConstructor` methods. If added to the environment's fields directly, the reconciler needs to be wrapped by `WrapReconcilerWithLoggingMetadata` manually.
```
```breaking developer
The testing environment's log outputs did previously use an existing logger (retrieved via `logging.GetLogger()`), if one existed, and created a new logger with default configuration otherwise. This has been changed, now the testing environment always creates a new logger, unless one has been passed into the builder via `WithLogger` explicitly. The created logger is configured to log at debug verbosity and use a human-readable format (text-formatted, with some coloring). While this is technically a breaking changes (in most cases logging will change from json-formatted at info level to text-formatted at debug level), there should only be very few cases in which this requires changes, if any at all.
```
