### PR TITLE
feat: add ReconcilerAs function to testing package

### DIFF
--- a/pkg/testing/complex_environment.go
+++ b/pkg/testing/complex_environment.go
@@ -489,3 +489,43 @@ func (r *reconcilerWithLoggingMetadata) Reconcile(ctx context.Context, req recon
 	}
 	return r.internal.Reconcile(ctx, req)
 }
+
+// ReconcilerAs takes either an *Environment, a *ComplexEnvironment, or a reconcile.Reconciler directly.
+// In case of an environment, it fetches the reconciler with the given name from the environment first.
+// In any case, it is unwrapped if of type *reconcilerWithLoggingMetadata, and then cast to the expected type T.
+// Returns an error if the reconciler is not found or cannot be cast to the requested type.
+// Panics if maybeName is not empty for an *Environment or reconcile.Reconciler, or has not exactly one element for a *ComplexEnvironment.
+func ReconcilerAs[T reconcile.Reconciler](env any, maybeName ...string) (T, error) {
+	var zero T
+	var r reconcile.Reconciler
+	switch e := env.(type) {
+	case *Environment:
+		if len(maybeName) != 0 {
+			panic(fmt.Errorf("maybeName must be empty for *Environment, got %v", maybeName))
+		}
+		r = e.Reconcilers[SimpleEnvironmentDefaultKey]
+	case *ComplexEnvironment:
+		if len(maybeName) != 1 {
+			panic(fmt.Errorf("ReconcilerAs: maybeName must have exactly one element for *ComplexEnvironment, got %v", maybeName))
+		}
+		r = e.Reconcilers[maybeName[0]]
+	case reconcile.Reconciler:
+		if len(maybeName) != 0 {
+			panic(fmt.Errorf("maybeName must be empty for reconcile.Reconciler, got %v", maybeName))
+		}
+		r = e
+	default:
+		panic(fmt.Errorf("env must either *Environment, *ComplexEnvironment, or reconcile.Reconciler, got %T", env))
+	}
+	if r == nil {
+		return zero, fmt.Errorf("reconciler not found")
+	}
+	if wrapped, ok := r.(*reconcilerWithLoggingMetadata); ok {
+		r = wrapped.internal
+	}
+	typed, ok := r.(T)
+	if !ok {
+		return zero, fmt.Errorf("reconciler of type %T is not assignable to target of type %T", r, zero)
+	}
+	return typed, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
#232 unintentionally introduced a breaking change: Since all reconcilers in the testing environment are now wrapped with the logging metadata dummy-reconciler, casting the return value of `env.Reconciler(...)` to a specific type - which was a common pattern before - does not work anymore.

To make migration as easy as possible, this PR introduces a helper function that can compensate for the removed casting capability.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
#232 unintentionally removed the possibility to cast the return value of `env.Reconciler(...)` to the type of reconciler previously passed into the environment, as it wraps every reconciler with a dummy reconciler to inject the logging metadata. As there is no nice, simple fix for this problem, a new function `ReconcilerAs[T reconcile.Reconciler(envOrRec, maybeName) (T, error)` was added to the `testing` package. The first argument must be of type `*Environment`, `*ComplexEnvironment`, or `reconcile.Reconciler`, the second one is the reconciler name and must be specified if and only if the type of the first one is `*ComplexEnvironment`. The function then fetches the reconciler from the environment (or uses the one given as argument), unwraps the logging metadata layer, if it exists, and then casts the reconciler into the type specified as generic argument. TL;DR: Replace `v, ok := env.Reconciler(<x>).(MyType)` with `v, err := testutils.ReconcilerAs[MyType](env, <x>)` in any code that uses the testing library.
```
