### PR TITLE
fix: deprecation comments

### DIFF
--- a/pkg/controller/hash.go
+++ b/pkg/controller/hash.go
@@ -44,6 +44,7 @@ func version8UUID(data []byte) (uuid.UUID, error) {
 // K8sNameUUID takes any number of string arguments and computes a hash out of it, which is then formatted as a version 8 UUID.
 // The arguments are joined with '/' before being hashed.
 // Returns an error if the list of ids is empty or contains only empty strings.
+//
 // Deprecated: Use NameHashSHAKE128Base32 instead.
 func K8sNameUUID(names ...string) (string, error) {
 	if err := validateIDs(names); err != nil {
@@ -69,6 +70,7 @@ func validateIDs(names []string) error {
 
 // K8sNameUUIDUnsafe works like K8sNameUUID, but panics instead of returning an error.
 // This should only be used in places where the input is guaranteed to be valid.
+//
 // Deprecated: Use NameHashSHAKE128Base32 instead.
 func K8sNameUUIDUnsafe(names ...string) string {
 	uuid, err := K8sNameUUID(names...)
@@ -80,6 +82,7 @@ func K8sNameUUIDUnsafe(names ...string) string {
 
 // K8sObjectUUID takes a client object and computes a hash out of the namespace and name, which is then formatted as a version 8 UUID.
 // An empty namespace will be replaced by "default".
+//
 // Deprecated: Use ObjectHashSHAKE128Base32 instead.
 func K8sObjectUUID(obj client.Object) (string, error) {
 	name, namespace := obj.GetName(), obj.GetNamespace()
@@ -91,6 +94,7 @@ func K8sObjectUUID(obj client.Object) (string, error) {
 
 // K8sObjectUUIDUnsafe works like K8sObjectUUID, but panics instead of returning an error.
 // This should only be used in places where the input is guaranteed to be valid.
+//
 // Deprecated: Use ObjectHashSHAKE128Base32 instead.
 func K8sObjectUUIDUnsafe(obj client.Object) string {
 	uuid, err := K8sObjectUUID(obj)

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -15,6 +15,7 @@ const (
 
 // K8sNameHash takes any number of string arguments and computes a hash out of it, which is then base32-encoded to be a valid DNS1123Subdomain k8s resource name
 // The arguments are joined with '/' before being hashed.
+//
 // Deprecated: Use NameHashSHAKE128Base32 instead.
 func K8sNameHash(ids ...string) string {
 	name := strings.Join(ids, "/")


### PR DESCRIPTION
for staticcheck to properly signal that an identifier should not be used see https://go.dev/wiki/Deprecated

On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
This PR fixes some missed staticcheck deprecation signals.

See https://go.dev/wiki/Deprecated
> To signal that an identifier should not be used, add a paragraph to its doc comment that begins with Deprecated: followed by some information about the deprecation, and a recommendation on what to use instead, if applicable. The paragraph does not have to be the last paragraph in the doc comment.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
deprecation docs fix for staticcheck
```
