### PR TITLE
fix: clusteraccess lib deletes and recreates (Cluster)RoleBinding resources if roleRef changed

### DIFF
--- a/pkg/clusteraccess/access.go
+++ b/pkg/clusteraccess/access.go
@@ -10,11 +10,11 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openmcp-project/controller-utils/pkg/pairs"
@@ -172,6 +172,8 @@ func EnsureClusterRole(ctx context.Context, c client.Client, name string, rules 
 // If it doesn't exist, it is created with the expected labels.
 // If it exists, but does not have the expected labels, a ResourceNotManagedError is returned.
 // The ClusterRoleBinding is returned.
+// If the RoleBinding already exists, but has a different RoleRef, it needs to be deleted and recreated, because the RoleRef is immutable.
+// In this case, a WaitingForRecreationError can be returned, if the deletion is not completed immediately (e.g. due to finalizers). The caller then needs to call this function again.
 func EnsureClusterRoleBinding(ctx context.Context, c client.Client, name, clusterRoleName string, subjects []rbacv1.Subject, expectedLabels ...Label) (*rbacv1.ClusterRoleBinding, error) {
 	crbm := resources.NewClusterRoleBindingMutator(name, subjects, resources.NewClusterRoleRef(clusterRoleName))
 	crbm.MetadataMutator().WithLabels(pairs.PairsToMap(expectedLabels))
@@ -186,6 +188,25 @@ func EnsureClusterRoleBinding(ctx context.Context, c client.Client, name, cluste
 	if found {
 		if err := FailIfNotManaged(crb, expectedLabels...); err != nil {
 			return nil, err
+		}
+
+		// check if RoleRef is changed
+		changed := crb.DeepCopy()
+		if err := crbm.Mutate(changed); err != nil {
+			return nil, fmt.Errorf("error mutating ClusterRoleBinding '%s': %w", crb.Name, err)
+		}
+		if !equality.Semantic.DeepEqual(changed.RoleRef, crb.RoleRef) {
+			// we need to delete and recreate the ClusterRoleBinding, because RoleRef is immutable
+			if err := c.Delete(ctx, crb); err != nil {
+				return nil, fmt.Errorf("error deleting ClusterRoleBinding '%s' for recreation: %w", crb.Name, err)
+			}
+			// check if deletion is completed, if not, return a WaitingForRecreationError
+			if err := c.Get(ctx, client.ObjectKeyFromObject(crb), crb); err == nil {
+				return nil, NewWaitingForRecreationError(crb, changed)
+			} else if !apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("error checking deletion of ClusterRoleBinding '%s': %w", crb.Name, err)
+			}
+			// if the error is IsNotFound, it means the deletion is completed and we can proceed with recreation
 		}
 	}
 	if err := resources.CreateOrUpdateResource(ctx, c, crbm); err != nil {
@@ -238,6 +259,8 @@ func EnsureRole(ctx context.Context, c client.Client, name, namespace string, ru
 // If it doesn't exist, it is created with the expected labels.
 // If it exists, but does not have the expected labels, a ResourceNotManagedError is returned.
 // The RoleBinding is returned.
+// If the RoleBinding already exists, but has a different RoleRef, it needs to be deleted and recreated, because the RoleRef is immutable.
+// In this case, a WaitingForRecreationError can be returned, if the deletion is not completed immediately (e.g. due to finalizers). The caller then needs to call this function again.
 func EnsureRoleBinding(ctx context.Context, c client.Client, name, namespace, roleName string, subjects []rbacv1.Subject, expectedLabels ...Label) (*rbacv1.RoleBinding, error) {
 	rbm := resources.NewRoleBindingMutator(name, namespace, subjects, resources.NewRoleRef(roleName))
 	rbm.MetadataMutator().WithLabels(pairs.PairsToMap(expectedLabels))
@@ -253,6 +276,25 @@ func EnsureRoleBinding(ctx context.Context, c client.Client, name, namespace, ro
 		if err := FailIfNotManaged(rb, expectedLabels...); err != nil {
 			return nil, err
 		}
+
+		// check if RoleRef is changed
+		changed := rb.DeepCopy()
+		if err := rbm.Mutate(changed); err != nil {
+			return nil, fmt.Errorf("error mutating RoleBinding '%s/%s': %w", rb.Namespace, rb.Name, err)
+		}
+		if !equality.Semantic.DeepEqual(changed.RoleRef, rb.RoleRef) {
+			// we need to delete and recreate the RoleBinding, because RoleRef is immutable
+			if err := c.Delete(ctx, rb); err != nil {
+				return nil, fmt.Errorf("error deleting RoleBinding '%s/%s' for recreation: %w", rb.Namespace, rb.Name, err)
+			}
+			// check if deletion is completed, if not, return a WaitingForRecreationError
+			if err := c.Get(ctx, client.ObjectKeyFromObject(rb), rb); err == nil {
+				return nil, NewWaitingForRecreationError(rb, changed)
+			} else if !apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("error checking deletion of RoleBinding '%s/%s': %w", rb.Namespace, rb.Name, err)
+			}
+			// if the error is IsNotFound, it means the deletion is completed and we can proceed with recreation
+		}
 	}
 	if err := resources.CreateOrUpdateResource(ctx, c, rbm); err != nil {
 		return nil, fmt.Errorf("error creating/updating RoleBinding '%s/%s': %w", rb.Namespace, rb.Name, err)
@@ -264,7 +306,7 @@ func EnsureRoleBinding(ctx context.Context, c client.Client, name, namespace, ro
 func CreateTokenForServiceAccount(ctx context.Context, c client.Client, sa *corev1.ServiceAccount, desiredDuration *time.Duration) (*ServiceAccountToken, error) {
 	tr := &authenticationv1.TokenRequest{}
 	if desiredDuration != nil {
-		tr.Spec.ExpirationSeconds = ptr.To((int64)(desiredDuration.Seconds()))
+		tr.Spec.ExpirationSeconds = new((int64)(desiredDuration.Seconds()))
 	}
 
 	sat := &ServiceAccountToken{

--- a/pkg/clusteraccess/access_test.go
+++ b/pkg/clusteraccess/access_test.go
@@ -1,6 +1,7 @@
 package clusteraccess_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -9,12 +10,15 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/yaml"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openmcp-project/controller-utils/pkg/clusteraccess"
 	"github.com/openmcp-project/controller-utils/pkg/pairs"
@@ -310,7 +314,33 @@ var _ = Describe("ClusterAccess", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should update the rolebinding if it exists and has the expected labels", func() {
+		It("should update the rolebinding if it exists and has the expected labels (roleRef unchanged)", func() {
+			rb := &rbacv1.RoleBinding{}
+			rb.SetName("testrb")
+			rb.SetNamespace("testns")
+			rb.SetLabels(testLabelsMap)
+			rb.RoleRef = expectedRoleRef()
+			rb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      "bar",
+					Namespace: "testns",
+				},
+			}
+			env := testutils.NewEnvironmentBuilder().WithFakeClient(nil).WithFakeClientBuilderCall("WithInterceptorFuncs", fakeClientRoleRefImmutabilityInterceptor()).WithInitObjects(rb, dummyRole(), dummyServiceAccount()).Build()
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(rb), rb)).To(Succeed())
+			Expect(rb.Labels).To(BeEquivalentTo(testLabelsMap))
+			oldUID := rb.GetUID()
+			rb, err := clusteraccess.EnsureRoleBinding(env.Ctx, env.Client(), rb.Name, rb.Namespace, expectedRoleRef().Name, expectedSubjects(), testLabelsList...)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(rb), rb)).To(Succeed())
+			Expect(rb.Labels).To(BeEquivalentTo(testLabelsMap))
+			Expect(rb.RoleRef).To(BeEquivalentTo(expectedRoleRef()))
+			Expect(rb.Subjects).To(BeEquivalentTo(expectedSubjects()))
+			Expect(rb.GetUID()).To(Equal(oldUID), "rolebinding should have been updated, not recreated")
+		})
+
+		It("should update the rolebinding if it exists and has the expected labels (roleRef changed, deletion succeeds)", func() {
 			rb := &rbacv1.RoleBinding{}
 			rb.SetName("testrb")
 			rb.SetNamespace("testns")
@@ -327,15 +357,56 @@ var _ = Describe("ClusterAccess", func() {
 					Namespace: "testns",
 				},
 			}
-			env := testutils.NewEnvironmentBuilder().WithFakeClient(nil).WithInitObjects(rb, dummyRole(), dummyServiceAccount()).Build()
+			env := testutils.NewEnvironmentBuilder().WithFakeClient(nil).WithFakeClientBuilderCall("WithInterceptorFuncs", fakeClientRoleRefImmutabilityInterceptor()).WithInitObjects(rb, dummyRole(), dummyServiceAccount()).Build()
 			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(rb), rb)).To(Succeed())
 			Expect(rb.Labels).To(BeEquivalentTo(testLabelsMap))
+			oldUID := rb.GetUID()
 			rb, err := clusteraccess.EnsureRoleBinding(env.Ctx, env.Client(), rb.Name, rb.Namespace, expectedRoleRef().Name, expectedSubjects(), testLabelsList...)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(rb), rb)).To(Succeed())
 			Expect(rb.Labels).To(BeEquivalentTo(testLabelsMap))
 			Expect(rb.RoleRef).To(BeEquivalentTo(expectedRoleRef()))
 			Expect(rb.Subjects).To(BeEquivalentTo(expectedSubjects()))
+			Expect(rb.GetUID()).ToNot(Equal(oldUID), "rolebinding should have been recreated due to roleRef change")
+		})
+
+		It("should update the rolebinding if it exists and has the expected labels (roleRef changed, deletion blocked)", func() {
+			rb := &rbacv1.RoleBinding{}
+			rb.SetName("testrb")
+			rb.SetNamespace("testns")
+			rb.SetLabels(testLabelsMap)
+			rb.SetFinalizers([]string{"deletion-blocker"})
+			rb.RoleRef = rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Name:     "foo",
+				Kind:     "Role",
+			}
+			rb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      "bar",
+					Namespace: "testns",
+				},
+			}
+			env := testutils.NewEnvironmentBuilder().WithFakeClient(nil).WithFakeClientBuilderCall("WithInterceptorFuncs", fakeClientRoleRefImmutabilityInterceptor()).WithInitObjects(rb, dummyRole(), dummyServiceAccount()).Build()
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(rb), rb)).To(Succeed())
+			Expect(rb.Labels).To(BeEquivalentTo(testLabelsMap))
+			oldUID := rb.GetUID()
+			_, err := clusteraccess.EnsureRoleBinding(env.Ctx, env.Client(), rb.Name, rb.Namespace, expectedRoleRef().Name, expectedSubjects(), testLabelsList...)
+			Expect(err).To(MatchError(clusteraccess.IsWaitingForRecreationError, "IsWaitingForRecreationError"))
+
+			// remove finalizer and try again, should succeed now
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(rb), rb)).To(Succeed())
+			rb.SetFinalizers(nil)
+			Expect(env.Client().Update(env.Ctx, rb)).To(Succeed())
+
+			rb, err = clusteraccess.EnsureRoleBinding(env.Ctx, env.Client(), rb.Name, rb.Namespace, expectedRoleRef().Name, expectedSubjects(), testLabelsList...)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(rb), rb)).To(Succeed())
+			Expect(rb.Labels).To(BeEquivalentTo(testLabelsMap))
+			Expect(rb.RoleRef).To(BeEquivalentTo(expectedRoleRef()))
+			Expect(rb.Subjects).To(BeEquivalentTo(expectedSubjects()))
+			Expect(rb.GetUID()).ToNot(Equal(oldUID), "rolebinding should have been recreated due to roleRef change")
 		})
 
 		It("should create a clusterrolebinding if it does not exist", func() {
@@ -365,7 +436,32 @@ var _ = Describe("ClusterAccess", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should update the clusterrolebinding if it exists and has the expected labels", func() {
+		It("should update the clusterrolebinding if it exists and has the expected labels (roleRef unchanged)", func() {
+			crb := &rbacv1.ClusterRoleBinding{}
+			crb.SetName("testcrb")
+			crb.SetLabels(testLabelsMap)
+			crb.RoleRef = expectedClusterRoleRef()
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      "bar",
+					Namespace: "testns",
+				},
+			}
+			env := testutils.NewEnvironmentBuilder().WithFakeClient(nil).WithFakeClientBuilderCall("WithInterceptorFuncs", fakeClientRoleRefImmutabilityInterceptor()).WithInitObjects(crb, dummyClusterRole(), dummyServiceAccount()).Build()
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(crb), crb)).To(Succeed())
+			Expect(crb.Labels).To(BeEquivalentTo(testLabelsMap))
+			oldUID := crb.GetUID()
+			crb, err := clusteraccess.EnsureClusterRoleBinding(env.Ctx, env.Client(), crb.Name, expectedClusterRoleRef().Name, expectedSubjects(), testLabelsList...)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(crb), crb)).To(Succeed())
+			Expect(crb.Labels).To(BeEquivalentTo(testLabelsMap))
+			Expect(crb.RoleRef).To(BeEquivalentTo(expectedClusterRoleRef()))
+			Expect(crb.Subjects).To(BeEquivalentTo(expectedSubjects()))
+			Expect(crb.GetUID()).To(Equal(oldUID), "clusterrolebinding should have been updated, not recreated")
+		})
+
+		It("should update the clusterrolebinding if it exists and has the expected labels (roleRef changed, deletion succeeds)", func() {
 			crb := &rbacv1.ClusterRoleBinding{}
 			crb.SetName("testcrb")
 			crb.SetLabels(testLabelsMap)
@@ -381,15 +477,55 @@ var _ = Describe("ClusterAccess", func() {
 					Namespace: "testns",
 				},
 			}
-			env := testutils.NewEnvironmentBuilder().WithFakeClient(nil).WithInitObjects(crb, dummyClusterRole(), dummyServiceAccount()).Build()
+			env := testutils.NewEnvironmentBuilder().WithFakeClient(nil).WithFakeClientBuilderCall("WithInterceptorFuncs", fakeClientRoleRefImmutabilityInterceptor()).WithInitObjects(crb, dummyClusterRole(), dummyServiceAccount()).Build()
 			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(crb), crb)).To(Succeed())
 			Expect(crb.Labels).To(BeEquivalentTo(testLabelsMap))
+			oldUID := crb.GetUID()
 			crb, err := clusteraccess.EnsureClusterRoleBinding(env.Ctx, env.Client(), crb.Name, expectedClusterRoleRef().Name, expectedSubjects(), testLabelsList...)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(crb), crb)).To(Succeed())
 			Expect(crb.Labels).To(BeEquivalentTo(testLabelsMap))
 			Expect(crb.RoleRef).To(BeEquivalentTo(expectedClusterRoleRef()))
 			Expect(crb.Subjects).To(BeEquivalentTo(expectedSubjects()))
+			Expect(crb.GetUID()).ToNot(Equal(oldUID), "clusterrolebinding should have been recreated due to roleRef change")
+		})
+
+		It("should update the clusterrolebinding if it exists and has the expected labels (roleRef changed, deletion blocked)", func() {
+			crb := &rbacv1.ClusterRoleBinding{}
+			crb.SetName("testcrb")
+			crb.SetLabels(testLabelsMap)
+			crb.SetFinalizers([]string{"deletion-blocker"})
+			crb.RoleRef = rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Name:     "foo",
+				Kind:     "ClusterRole",
+			}
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      "bar",
+					Namespace: "testns",
+				},
+			}
+			env := testutils.NewEnvironmentBuilder().WithFakeClient(nil).WithFakeClientBuilderCall("WithInterceptorFuncs", fakeClientRoleRefImmutabilityInterceptor()).WithInitObjects(crb, dummyClusterRole(), dummyServiceAccount()).Build()
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(crb), crb)).To(Succeed())
+			Expect(crb.Labels).To(BeEquivalentTo(testLabelsMap))
+			oldUID := crb.GetUID()
+			_, err := clusteraccess.EnsureClusterRoleBinding(env.Ctx, env.Client(), crb.Name, expectedClusterRoleRef().Name, expectedSubjects(), testLabelsList...)
+			Expect(err).To(MatchError(clusteraccess.IsWaitingForRecreationError, "IsWaitingForRecreationError"))
+
+			// remove finalizer and try again, should succeed now
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(crb), crb)).To(Succeed())
+			crb.SetFinalizers(nil)
+			Expect(env.Client().Update(env.Ctx, crb)).To(Succeed())
+
+			crb, err = clusteraccess.EnsureClusterRoleBinding(env.Ctx, env.Client(), crb.Name, expectedClusterRoleRef().Name, expectedSubjects(), testLabelsList...)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(crb), crb)).To(Succeed())
+			Expect(crb.Labels).To(BeEquivalentTo(testLabelsMap))
+			Expect(crb.RoleRef).To(BeEquivalentTo(expectedClusterRoleRef()))
+			Expect(crb.Subjects).To(BeEquivalentTo(expectedSubjects()))
+			Expect(crb.GetUID()).ToNot(Equal(oldUID), "clusterrolebinding should have been recreated due to roleRef change")
 		})
 
 	})
@@ -531,3 +667,35 @@ var _ = Describe("ClusterAccess", func() {
 	})
 
 })
+
+func fakeClientRoleRefImmutabilityInterceptor() interceptor.Funcs {
+	return interceptor.Funcs{
+		Create: testutils.InjectUIDOnObjectCreation(nil), // UUIDs can be used to verify whether an object has been recreated
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			// mimick the regular client's behavior of rejecting updates to the roleRef of a RoleBinding or ClusterRoleBinding
+			switch o := obj.(type) {
+			case *rbacv1.RoleBinding:
+				old := &rbacv1.RoleBinding{}
+				if err := c.Get(ctx, client.ObjectKeyFromObject(o), old); err != nil {
+					return err
+				}
+				if !equality.Semantic.DeepEqual(old.RoleRef, o.RoleRef) {
+					return apierrors.NewInvalid(rbacv1.SchemeGroupVersion.WithKind("RoleBinding").GroupKind(), o.Name, field.ErrorList{
+						field.Invalid(field.NewPath("roleRef"), o.RoleRef, "cannot be updated"),
+					})
+				}
+			case *rbacv1.ClusterRoleBinding:
+				old := &rbacv1.ClusterRoleBinding{}
+				if err := c.Get(ctx, client.ObjectKeyFromObject(o), old); err != nil {
+					return err
+				}
+				if !equality.Semantic.DeepEqual(old.RoleRef, o.RoleRef) {
+					return apierrors.NewInvalid(rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding").GroupKind(), o.Name, field.ErrorList{
+						field.Invalid(field.NewPath("roleRef"), o.RoleRef, "cannot be updated"),
+					})
+				}
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	}
+}

--- a/pkg/clusteraccess/errors.go
+++ b/pkg/clusteraccess/errors.go
@@ -71,3 +71,59 @@ func IsResourceNotManagedError(err error) bool {
 	}
 	return false
 }
+
+// NewWaitingForRecreationError creates a new WaitingForRecreationError.
+func NewWaitingForRecreationError(oldObj, newObj client.Object) *WaitingForRecreationError {
+	return &WaitingForRecreationError{
+		Old: oldObj,
+		New: newObj,
+	}
+}
+
+type WaitingForRecreationError struct {
+	Old client.Object
+	New client.Object
+}
+
+var _ error = &WaitingForRecreationError{}
+
+func (e *WaitingForRecreationError) Error() string {
+	var kind string
+	var name string
+	var namespace string
+	if e.Old != nil {
+		kind = e.Old.GetObjectKind().GroupVersionKind().Kind
+		name = e.Old.GetName()
+		namespace = e.Old.GetNamespace()
+	}
+	if e.New != nil {
+		if kind == "" {
+			kind = e.New.GetObjectKind().GroupVersionKind().Kind
+		}
+		if name == "" {
+			name = e.New.GetName()
+		}
+		if namespace == "" {
+			namespace = e.New.GetNamespace()
+		}
+	}
+	if kind == "" {
+		kind = "resource"
+	}
+	nsMod := ""
+	if namespace != "" {
+		nsMod = namespace + "/"
+	}
+	return fmt.Sprintf("%s '%s%s' needs to be recreated, but the deletion is not completed yet. Please call this function again later.", kind, nsMod, name)
+}
+
+// IsWaitingForRecreationError returns true if the error is non-nil and of type *WaitingForRecreationError.
+func IsWaitingForRecreationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if _, ok := err.(*WaitingForRecreationError); ok {
+		return true
+	}
+	return false
+}

--- a/pkg/testing/environment.go
+++ b/pkg/testing/environment.go
@@ -78,9 +78,9 @@ type EnvironmentBuilder struct {
 	*ComplexEnvironmentBuilder
 }
 
-// NewEnvironmentBuilder creates a new SimpleEnvironmentBuilder.
-// Use this to construct a SimpleEnvironment, if you need only one reconciler and one cluster.
-// For more complex test scenarios, use NewEnvironmentBuilder() instead.
+// NewEnvironmentBuilder creates a new EnvironmentBuilder.
+// Use this to construct a simple Environment, if you need only one reconciler and one cluster.
+// For more complex test scenarios, use NewComplexEnvironmentBuilder() instead.
 func NewEnvironmentBuilder() *EnvironmentBuilder {
 	res := &EnvironmentBuilder{
 		ComplexEnvironmentBuilder: NewComplexEnvironmentBuilder(),


### PR DESCRIPTION
**What this PR does / why we need it**:
The `clusteraccess` library has functions for creating and updating `RoleBinding` and `ClusterRoleBinding` resources. These did not consider the fact that the `roleRef` field of these resources is immutable, leading to a persistent error if the caller of the functions changes the role ref of an existing (Cluster)RoleBinding. This PR fixes that.

**Which issue(s) this PR fixes**:
Basically the fix for https://github.com/openmcp-project/cluster-provider-gardener/issues/234.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The `clusteraccess` library's `EnsureRoleBinding` and `EnsureClusterRoleBinding` functions now take into account that the `roleRef` field of a `RoleBinding`/`ClusterRoleBinding` is immutable. If a call would update this field on an existing resource, the resource is deleted and recreated instead. If the deletion does not immediately succeed (e.g. due to finalizers), the function returns an `WaitingForRecreationError`, indicating that it needs to be called again to finish updating the resource to the desired state.
```
