### PR TITLE
fix: un-deprecate K8sNameUUID function

### DIFF
--- a/pkg/controller/hash.go
+++ b/pkg/controller/hash.go
@@ -45,7 +45,8 @@ func version8UUID(data []byte) (uuid.UUID, error) {
 // The arguments are joined with '/' before being hashed.
 // Returns an error if the list of ids is empty or contains only empty strings.
 //
-// Deprecated: Use NameHashSHAKE128Base32 instead.
+// This is a legacy function which is mainly kept in to avoid breaking changes that are hard to mitigate.
+// For new code, it is recommended to use NameHashSHAKE128Base32 instead.
 func K8sNameUUID(names ...string) (string, error) {
 	if err := validateIDs(names); err != nil {
 		return "", err


### PR DESCRIPTION
**What this PR does / why we need it**:
Un-deprecates the `K8sNameUUID` function.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `K8sNameUUID` function is not deprecated anymore. The reason for this is that it is used in a few places where it would be very cumbersome to replace and the advantages of a change are not worth the effort required for migration.
```
