### PR TITLE
chore: run 'task generate' on renovate branches

### DIFF
--- a/.github/workflows/renovate-generate.yaml
+++ b/.github/workflows/renovate-generate.yaml
@@ -1,0 +1,14 @@
+name: Renovate Generate
+
+on:
+  push:
+    branches:
+      - "renovate/**"
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    uses: openmcp-project/build/.github/workflows/renovate-generate.lib.yaml@0853da91ab09626a07d3495f3d31bed3ede22ed5 # main
+    secrets: inherit


### PR DESCRIPTION
**What this PR does / why we need it**:
Some PRs require an additional 'task generate' after a renovate PR.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
