### PR TITLE
feat: add FIPS enforcement utility function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,4 +21,4 @@
 - [Testing](libs/testing.md)
 - [Thread Management](libs/threads.md)
 - [Webhooks](libs/webhooks.md)
-
+- [FIPS](libs/fips.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 - [Controller Utility Functions](libs/controller.md)
 - [Custom Resource Definitions](libs/crds.md)
 - [Error Handling](libs/errors.md)
+- [FIPS](libs/fips.md)
 - [Image Parsing](libs/image.md)
 - [JSON Patch](libs/jsonpatch.md)
 - [Logging](libs/logging.md)
@@ -21,4 +22,4 @@
 - [Testing](libs/testing.md)
 - [Thread Management](libs/threads.md)
 - [Webhooks](libs/webhooks.md)
-- [FIPS](libs/fips.md)
+

--- a/docs/libs/fips.md
+++ b/docs/libs/fips.md
@@ -1,0 +1,5 @@
+# FIPS
+
+The `pkg/fips` package contains the `Verify` utility functions that checks if FIPS support is intended by this binary.
+If yes, it checks if FIPS is enabled.
+If it is not enabled, the process exits immediately.

--- a/pkg/fips/fips.go
+++ b/pkg/fips/fips.go
@@ -17,7 +17,7 @@ var fipsEnforced string
 // If yes, it checks if FIPS mode is enabled.
 // If it is not enabled but is expected to be enabled it exits the process.
 func Verify(ctx context.Context) {
-	log, ctx := logging.FromContextOrNew(ctx, nil)
+	log, _ := logging.FromContextOrNew(ctx, nil)
 
 	if fipsEnforced != "true" {
 		return

--- a/pkg/fips/fips.go
+++ b/pkg/fips/fips.go
@@ -1,0 +1,31 @@
+package fips
+
+import (
+	"context"
+	"crypto/fips140"
+	"fmt"
+	"os"
+
+	"github.com/openmcp-project/controller-utils/pkg/logging"
+)
+
+// fipsEnforced is set to "true" at link time when built with FIPS support.
+// Standard builds leave it empty — enforcement never triggers.
+var fipsEnforced string
+
+// Verify checks if the binary is built with FIPS compliance.
+// If yes, it checks if FIPS mode is enabled.
+// If it is not enabled but is expected to be enabled it exits the process.
+func Verify(ctx context.Context) {
+	log, ctx := logging.FromContextOrNew(ctx, nil)
+
+	if fipsEnforced != "true" {
+		return
+	}
+
+	if !fips140.Enabled() {
+		err := fmt.Errorf("FIPS 140 is disabled but enforcement is enabled")
+		log.Error(err, "FIPS 140 is disabled but enforcement is active")
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a `fips.Verif` utility function.
This function is intended to be called by controllers when being started.
The function checks if the binary was built with FIPS mode intended. This is indicated by a link time flag.
If FIPS mode enabled is intended, the function will check if FIPS is actually enabled.
If not, the process will be terminated immediately.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Add FIPS enforcement utility function
```
