### PR TITLE
feat: add library for improved templating errros

### DIFF
--- a/docs/libs/errors.md
+++ b/docs/libs/errors.md
@@ -1,5 +1,7 @@
 # Error Handling
 
+## ReasonableError
+
 The `pkg/errors` package contains the `ReasonableError` type, which combines a normal `error` with a reason string. This is useful for errors that happen during reconciliation for updating the resource's status with a reason for the error later on.
 
 ### Noteworthy Functions:
@@ -8,6 +10,40 @@ The `pkg/errors` package contains the `ReasonableError` type, which combines a n
 - `Errorf(...)` can be used to wrap an existing `ReasonableError` together with a new error, similarly to how `fmt.Errorf(...)` does it for standard errors.
 - `NewReasonableErrorList(...)` or `Join(...)` can be used to work with lists of errors. `Aggregate()` turns them into a single error again.
 
-### Ignore Invalid User Input
+## Ignoring Invalid User Input
 
 `ErrInvalidUserInput` can be used to create errors that can be ignored with `IgnoreInvalidUserInput(...)` at the end of reconciliation. This allows you to handle errors properly and skip unnecessary requeues.
+
+## Templating Errors
+
+The `TemplateErrorBuilder` from `pkg/errors` can be used to construct more useful errors out of the default golang templating errors.
+
+The standard error message for a missing key looks like this:
+```
+foo: bar
+asdf: template: mytemplate:2:16: executing "mytemplate" at <.inputs.asdf>: map has no entry for key "inputs"
+```
+
+With the enhanced templating error logic, it can be turned into this:
+```
+template: mytemplate:2:16: executing "mytemplate" at <.inputs.asdf>: map has no entry for key "inputs"
+template source:
+1:  foo: bar
+2:  asdf: {{ .inputs.asdf }}
+                    ˆ≈≈≈≈≈≈≈
+3:  test: true
+
+template input:
+	foo: "bar"
+	asdf: "asdf"
+```
+
+Use `TemplateErrorBuilder(<original error>)` to create the builder, then add more context with these builder methods:
+  - `WithSource` adds the source template.
+  - `WithSourceSnippetFormat` allows to overwrite the default values for
+    - lines before the error (default: `5`)
+    - lines after the error (default: `5`)
+    - length of the prefix (line number, colon, following whitespace) (default: `6`)
+  - `WithFormattedOutput` can be used if the templating itself was successful, but the generated output does not match the expected format or is wrong in some other way.
+  - `WithInput` sets the template's input values.
+Then use the `Build()` method to generate the error message.

--- a/pkg/errors/template.go
+++ b/pkg/errors/template.go
@@ -1,0 +1,208 @@
+package errors
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// DefaultLinesBefore the number of lines before the error line that are printed.
+	DefaultLinesBefore = 5
+	// DefaultLinesAfter the number of lines after the error line that are printed.
+	DefaultLinesAfter = 5
+	// DefaultLineNumberPrefixLength is the fixed width of the code line prefix containing the line number.
+	DefaultLineNumberPrefixLength = 6
+)
+
+var (
+	errorLineColumnRegexp = regexp.MustCompile("(?m):([0-9]+)(:([0-9]+))?:")
+	// yamlLineRegexp matches the "line N" location marker used by
+	// sigs.k8s.io/yaml / go-yaml when the generated YAML fails to parse
+	// (e.g. "error converting YAML to JSON: yaml: line 19: could not find expected ':'").
+	yamlLineRegexp = regexp.MustCompile(`line ([0-9]+)`)
+)
+
+// TemplateError wraps a go templating error and adds more human-readable information.
+type TemplateError struct {
+	err                              error
+	source                           *string
+	output                           *string
+	input                            map[string]any
+	message                          string
+	inputFormatter                   *TemplateInputFormatter
+	sourceCodePrepend                int
+	sourceCodeAppend                 int
+	sourceCodeLineNumberPrefixLength int
+}
+
+// TemplateErrorBuilder creates a new TemplateError.
+func TemplateErrorBuilder(err error) *TemplateError {
+	return &TemplateError{
+		err:                              err,
+		message:                          err.Error(),
+		sourceCodePrepend:                DefaultLinesBefore,
+		sourceCodeAppend:                 DefaultLinesAfter,
+		sourceCodeLineNumberPrefixLength: DefaultLineNumberPrefixLength,
+	}
+}
+
+// WithSource adds the template source code to the error.
+func (e *TemplateError) WithSource(source *string) *TemplateError {
+	e.source = source
+	return e
+}
+
+// WithSourceSnippetFormat adds the number of lines before and after the error line that are printed in the source code snippet.
+// The lineNumberPrefixLength specifies the total length of the line number prefix, consisting of the line number, a colon, and then whitespace to align the code.
+func (e *TemplateError) WithSourceSnippetFormat(linesBefore, linesAfter, lineNumberPrefixLength int) *TemplateError {
+	e.sourceCodePrepend = linesBefore
+	e.sourceCodeAppend = linesAfter
+	e.sourceCodeLineNumberPrefixLength = lineNumberPrefixLength
+	return e
+}
+
+// WithFormattedOutput adds the rendered template output to the error. Used
+// when the failure occurs after successful Go-template execution (e.g. the
+// generated YAML is syntactically invalid or does not match the expected
+// schema) - the user cannot otherwise see the generated document, so surface
+// a snippet around the failing line.
+func (e *TemplateError) WithFormattedOutput(output *string) *TemplateError {
+	e.output = output
+	return e
+}
+
+// WithInput adds the template input with a formatter to the error.
+func (e *TemplateError) WithInput(input map[string]any, inputFormatter *TemplateInputFormatter) *TemplateError {
+	e.input = input
+	e.inputFormatter = inputFormatter
+	return e
+}
+
+// Build builds the error message.
+func (e *TemplateError) Build() *TemplateError {
+	builder := strings.Builder{}
+	builder.WriteString(e.err.Error())
+
+	if e.source != nil {
+		builder.WriteString("\ntemplate source:\n")
+		builder.WriteString(e.formatSource())
+	}
+
+	if e.output != nil {
+		builder.WriteString("\ntemplated output:\n")
+		builder.WriteString(e.formatOutput())
+	}
+
+	if e.input != nil && e.inputFormatter != nil {
+		builder.WriteString("\ntemplate input:\n")
+		builder.WriteString(e.inputFormatter.Format(e.input, "\t"))
+	}
+
+	e.message = builder.String()
+	return e
+}
+
+// Error returns the error message.
+func (e *TemplateError) Error() string {
+	return e.message
+}
+
+// formatSource extracts the significant template source code that was the reason of the template error.
+func (e *TemplateError) formatSource() string {
+	line, column := extractLineColumn(e.err.Error())
+	if line == 0 {
+		return ""
+	}
+	return CreateSourceSnippet(line, column, strings.Split(*e.source, "\n"), e.sourceCodePrepend, e.sourceCodeAppend, e.sourceCodeLineNumberPrefixLength)
+}
+
+// formatOutput extracts the significant rendered output lines around the
+// location reported by a downstream YAML parser.
+func (e *TemplateError) formatOutput() string {
+	line, column := extractLineColumn(e.err.Error())
+	if line == 0 {
+		return ""
+	}
+	return CreateSourceSnippet(line, column, strings.Split(*e.output, "\n"), e.sourceCodePrepend, e.sourceCodeAppend, e.sourceCodeLineNumberPrefixLength)
+}
+
+// extractLineColumn tries the Go-template ":N:M:" location marker first,
+// then falls back to the YAML "line N" marker. Returns (0, 0) if neither
+// matches.
+func extractLineColumn(errStr string) (int, int) {
+	if m := errorLineColumnRegexp.FindStringSubmatch(errStr); m != nil {
+		line, err := strconv.Atoi(m[1])
+		if err != nil {
+			return 0, 0
+		}
+		column := 0
+		if len(m) >= 4 && m[3] != "" {
+			if c, err := strconv.Atoi(m[3]); err == nil {
+				column = c
+			}
+		}
+		return line, column
+	}
+	if m := yamlLineRegexp.FindStringSubmatch(errStr); m != nil {
+		line, err := strconv.Atoi(m[1])
+		if err != nil {
+			return 0, 0
+		}
+		return line, 0
+	}
+	return 0, 0
+}
+
+// CreateSourceSnippet creates an excerpt of lines of source code, containing some lines before
+// and after the error line.
+// The error line and column will be highlighted and looks like this:
+// 14:     updateStrategy: patch
+// 15:
+// 16:     name: test
+// 17:     namespace: {{ .imports.namespace }}
+//
+//	ˆ≈≈≈≈≈≈≈
+//
+// 18:
+// 19:     exportsFromManifests:
+// 20:     - key: ingressClass
+func CreateSourceSnippet(errorLine, errorColumn int, source []string, linesBefore, linesAfter, lineNumberPrefixLength int) string {
+	var (
+		sourceStartLine, sourceEndLine int
+		formatted                      = strings.Builder{}
+	)
+
+	// convert to zero base index
+	errorLine -= 1
+
+	// calculate the starting line of the source code
+	sourceStartLine = max(errorLine-linesBefore, 0)
+
+	errorLine -= sourceStartLine
+	source = source[sourceStartLine:]
+
+	// calculate the ending line of the source code
+	sourceEndLine = min(errorLine+linesAfter+1, len(source))
+
+	source = source[:sourceEndLine]
+
+	for i, line := range source {
+		// for printing, the line has to be converted back to one based index
+		realLine := sourceStartLine + i + 1
+		realLineWidth := int(math.Log10(float64(realLine)) + 1)
+		// account for the colon after the line number
+		repeat := max(lineNumberPrefixLength-realLineWidth-1, 0)
+		// the prefix contains the line number and some amount of whitespaces to keep the correct indentation
+		prefix := fmt.Sprintf("%d:%s", realLine, strings.Repeat(" ", repeat))
+		fmt.Fprintf(&formatted, "%s%s\n", prefix, line)
+
+		if i == errorLine {
+			fmt.Fprintf(&formatted, "%s\u02c6≈≈≈≈≈≈≈\n", strings.Repeat(" ", errorColumn+len(prefix)))
+		}
+	}
+
+	return formatted.String()
+}

--- a/pkg/errors/template_format.go
+++ b/pkg/errors/template_format.go
@@ -1,0 +1,151 @@
+package errors
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	// compressThresholdBytes specifies the threshold in bytes at which the value of an input key are compressed.
+	compressThresholdBytes = 512
+	// removeValuesMaxDepth is the maximum depth at which values of sensitive input keys are removed.
+	// Beyond the maximum depth the values are getting truncated.
+	removeValuesMaxDepth = 10
+)
+
+func init() {
+	gob.Register(map[string]interface{}{})
+}
+
+// The TemplateInputFormatter formats the inputs of a template in a human-readable format.
+type TemplateInputFormatter struct {
+	prettyPrint   bool
+	sensitiveKeys sets.Set[string]
+}
+
+// NewTemplateInputFormatter creates a new template input formatter.
+// When prettyPrint is set to true, the json output will be formatted with easier readable indentation.
+// The parameter sensitiveKeys can contain template input keys which may contain sensitive data.
+// When such a key is encountered during formatting, the values of the respective key will be removed.
+func NewTemplateInputFormatter(prettyPrint bool, sensitiveKeys ...string) *TemplateInputFormatter {
+	return &TemplateInputFormatter{
+		prettyPrint:   prettyPrint,
+		sensitiveKeys: sets.New(sensitiveKeys...),
+	}
+}
+
+// Format formats the template input into a string value.
+// The given prefix is prepended to each line of the formatted output.
+func (f *TemplateInputFormatter) Format(input map[string]interface{}, prefix string) string {
+	if input == nil {
+		return ""
+	}
+
+	var (
+		err       error
+		marshaled []byte
+		formatted strings.Builder
+	)
+
+	for k, v := range input {
+		// If the current key is contained in the list of sensitive keys, all values in each sub-tree will be removed.
+		if f.sensitiveKeys.Has(k) {
+			source, ok := v.(map[string]interface{})
+			if ok {
+				// The map is deep copied so that the original input value is not getting modified.
+				v, err = deepCopyMap(source)
+				if err != nil {
+					v = ""
+				}
+			}
+			v = removeValue(v, 1)
+		}
+
+		if f.prettyPrint {
+			marshaled, err = json.MarshalIndent(v, prefix, "  ")
+		} else {
+			marshaled, err = json.Marshal(v)
+		}
+
+		if err != nil {
+			marshaled = []byte("")
+		}
+
+		// compress values if pretty print is not enabled and the length exceeds the threshold.
+		if !f.prettyPrint && len(marshaled) > compressThresholdBytes {
+			fmt.Fprintf(&formatted, "%s%s: >gzip>base64> %s\n", prefix, k, compressAndEncode(string(marshaled)))
+		} else {
+			fmt.Fprintf(&formatted, "%s%s: %s\n", prefix, k, string(marshaled))
+		}
+	}
+
+	return formatted.String()
+}
+
+// removeValue removes the value of the input parameter.
+// If the input is a map, all leaf values are removed until a certain depth.
+// When the maximum depth is reached, the current leaf of the map will be truncated.
+func removeValue(val interface{}, depth uint) interface{} {
+	m, ok := val.(map[string]interface{})
+	if ok && depth <= removeValuesMaxDepth {
+		for k, v := range m {
+			m[k] = removeValue(v, depth+1)
+		}
+	} else {
+		if val != nil {
+			val = reflect.TypeOf(val).String()
+		}
+		val = fmt.Sprintf("[...] (%s)", val)
+	}
+
+	return val
+}
+
+// compressAndEncode compresses the input string with gzip and encodes the output with base64.
+func compressAndEncode(input string) string {
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+
+	_, err := writer.Write([]byte(input))
+	if err != nil {
+		return ""
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return ""
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return encoded
+}
+
+// deepCopyMap deep copies a map.
+func deepCopyMap(in map[string]interface{}) (map[string]interface{}, error) {
+	var (
+		buf  bytes.Buffer
+		copy map[string]interface{}
+	)
+
+	encoder := gob.NewEncoder(&buf)
+	err := encoder.Encode(in)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := gob.NewDecoder(&buf)
+	err = decoder.Decode(&copy)
+	if err != nil {
+		return nil, err
+	}
+
+	return copy, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR basically moves the improved templating error logic from the landscaper repository into the controller-utils library for better reusability.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `pkg/errors` package now contains methods for enhancing templating errors.
```
